### PR TITLE
fix: docker image path in compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ name: ado-asana-sync
 
 services:
   sync:
-    image: ghcr.io/danstis/ado-asana-sync-sync:latest
+    image: ghcr.io/danstis/ado-asana-sync:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This PR corrects the Docker image path in the compose file. The previous image path was incorrect, leading to potential issues in the deployment process. The correct image path has now been set.