### PR TITLE
feat(sync): implement threading lock for database thread safety

### DIFF
--- a/ado_asana_sync/sync/app.py
+++ b/ado_asana_sync/sync/app.py
@@ -8,6 +8,7 @@ Classes:
 
 import logging
 import os
+import threading
 from typing import Optional
 
 import asana  # type: ignore
@@ -50,6 +51,7 @@ class App:
         asana_tag_name: Defines the name of the Asana tag to add to synced items.
         asana_tag_gid: stores the tag id for the named asana tag in asana_tag_name.
         db: TinyDB database.
+        db_lock: Lock for the TinyDB database.
         matches: TinyDB table named "matches".
         config: TinyDB table named "config".
     """
@@ -84,6 +86,7 @@ class App:
         self.asana_tag_gid = None
         self.asana_tag_name = ASANA_TAG_NAME
         self.db = None
+        self.db_lock = threading.Lock()
         self.matches = None
         self.config = None
         self.sleep_time = SLEEP_TIME

--- a/ado_asana_sync/sync/task_item.py
+++ b/ado_asana_sync/sync/task_item.py
@@ -117,9 +117,10 @@ class TaskItem:
             None: If there is no matching item.
         """
         query = Query().ado_id == ado_id
-        if app.matches.contains(query):
-            item = app.matches.search(query)
-            return cls(**item[0])
+        with app.db_lock:
+            if app.matches.contains(query):
+                item = app.matches.search(query)
+                return cls(**item[0])
         return None
 
     @classmethod
@@ -145,9 +146,10 @@ class TaskItem:
         query = (task.ado_id == ado_id) | (task.asana_gid == asana_gid)
 
         # return the first matching item, or return None if not found.
-        if app.matches.contains(query):
-            item = app.matches.search(query)
-            return cls(**item[0])
+        with app.db_lock:
+            if app.matches.contains(query):
+                item = app.matches.search(query)
+                return cls(**item[0])
         return None
 
     def save(self, app: App) -> None:
@@ -174,10 +176,11 @@ class TaskItem:
             "updated_date": self.updated_date,
         }
         query = Query().ado_id == task_data["ado_id"]
-        if app.matches.contains(query):
-            app.matches.update(task_data, query)
-        else:
-            app.matches.insert(task_data)
+        with app.db_lock:
+            if app.matches.contains(query):
+                app.matches.update(task_data, query)
+            else:
+                app.matches.insert(task_data)
 
     def is_current(self, app: App) -> bool:
         """

--- a/tests/sync/test_task_item.py
+++ b/tests/sync/test_task_item.py
@@ -40,12 +40,17 @@ class TestTaskItem(unittest.TestCase):
     def test_returns_task_item_with_matching_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.matches = MagicMock()
+        app.db_lock = MagicMock()
+
+        with app.db_lock:
+            app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = True
+        with app.db_lock:
+            app.matches.contains.return_value = True
         # Mock the search method of the matches table to return a mock TaskItem object
-        app.matches.search.return_value = [TEST_DB_ITEM_1]
+        with app.db_lock:
+            app.matches.search.return_value = [TEST_DB_ITEM_1]
 
         # Call the find_by_ado_id method with a valid ADO ID
         result = TaskItem.find_by_ado_id(app, 1)
@@ -68,10 +73,14 @@ class TestTaskItem(unittest.TestCase):
     def test_returns_task_item_with_no_matching_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.matches = MagicMock()
+        app.db_lock = MagicMock()
+
+        with app.db_lock:
+            app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return False
-        app.matches.contains.return_value = False
+        with app.db_lock:
+            app.matches.contains.return_value = False
 
         # Call the find_by_ado_id method with a non-existing ADO ID
         result = TaskItem.find_by_ado_id(app, 1)
@@ -83,7 +92,10 @@ class TestTaskItem(unittest.TestCase):
     def test_returns_none_if_ado_id_and_asana_gid_are_none(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.matches = MagicMock()
+        app.db_lock = MagicMock()
+
+        with app.db_lock:
+            app.matches = MagicMock()
 
         # Call the search method with None for both ado_id and asana_gid
         result = TaskItem.search(app, None, None)
@@ -95,12 +107,17 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_valid_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.matches = MagicMock()
+        app.db_lock = MagicMock()
+
+        with app.db_lock:
+            app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = True
+        with app.db_lock:
+            app.matches.contains.return_value = True
         # Mock the search method of the matches table to return a mock TaskItem object
-        app.matches.search.return_value = [TEST_DB_ITEM_1]
+        with app.db_lock:
+            app.matches.search.return_value = [TEST_DB_ITEM_1]
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, ado_id=1)
@@ -111,12 +128,17 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_valid_asana_guid(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.matches = MagicMock()
+        app.db_lock = MagicMock()
+
+        with app.db_lock:
+            app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = True
+        with app.db_lock:
+            app.matches.contains.return_value = True
         # Mock the search method of the matches table to return a mock TaskItem object
-        app.matches.search.return_value = [TEST_DB_ITEM_1]
+        with app.db_lock:
+            app.matches.search.return_value = [TEST_DB_ITEM_1]
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, asana_gid="123456")
@@ -127,10 +149,14 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_invalid_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.matches = MagicMock()
+        app.db_lock = MagicMock()
+
+        with app.db_lock:
+            app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = False
+        with app.db_lock:
+            app.matches.contains.return_value = False
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, ado_id=5)
@@ -141,10 +167,14 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_invalid_asana_guid(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.matches = MagicMock()
+        app.db_lock = MagicMock()
+
+        with app.db_lock:
+            app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = False
+        with app.db_lock:
+            app.matches.contains.return_value = False
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, asana_gid="987654")


### PR DESCRIPTION
### **User description**
Fixes #278


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a threading lock (`db_lock`) to the `App` class to ensure thread safety when accessing the TinyDB database.
- Wrapped all database operations in the `sync.py` and `task_item.py` modules with the threading lock to prevent data corruption.
- Updated unit tests in `test_task_item.py` to accommodate the new threading lock mechanism, ensuring that mock objects respect the lock usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Add threading lock for TinyDB database access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/app.py

<li>Added threading lock for TinyDB database access.<br> <li> Introduced <code>db_lock</code> attribute in <code>App</code> class.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/282/files#diff-c51ca1b6008633c922edec7764f3abd21dfa03be9aef0a10769fbe379a7bae39">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Ensure thread safety for database operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<li>Wrapped database operations with threading lock.<br> <li> Ensured thread safety for database access.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/282/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+17/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>task_item.py</strong><dd><code>Implement threading lock in TaskItem methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/task_item.py

<li>Used threading lock for database queries and updates.<br> <li> Enhanced thread safety in <code>TaskItem</code> methods.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/282/files#diff-0fd0b95374ef93889cff36010b72b44a77c0a57d693a2d3a99ad82917bcb89e6">+13/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_item.py</strong><dd><code>Update tests to incorporate threading lock usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_task_item.py

<li>Updated tests to use threading lock.<br> <li> Ensured mock objects respect threading lock usage.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/282/files#diff-960fbea415e87edb53e4658950b63a6a514be88b83eaea5906f3d7ff3b4b30da">+46/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information