### PR TITLE
fix: handle case-insensitive comparisons in `matching_user` function

### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -558,7 +558,10 @@ def matching_user(user_list: list[dict], ado_user: ADOAssignedUser) -> dict | No
     if ado_user is None:
         return None
     for user in user_list:
-        if user["email"] == ado_user.email or user["name"] == ado_user.display_name:
+        if (
+            user["email"].lower() == ado_user.email.lower() or
+            user["name"].lower() == ado_user.display_name.lower()
+        ):
             return user
     return None
 

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -267,5 +267,131 @@ class TestGetAsanaTaskByName(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestMatchingUser(unittest.TestCase):
+    # Tests that matching_user returns the matching user when the email exists in the user_list.
+    def test_matching_user_matching_email_exists(self):
+        user_list = [
+            {"email": "user1@example.com", "name": "User 1"},
+            {"email": "user2@example.com", "name": "User 2"},
+            {"email": "user3@example.com", "name": "User 3"},
+        ]
+        ado_user = ADOAssignedUser(display_name="User Two", email="user2@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertEqual(result, {"email": "user2@example.com", "name": "User 2"})
+
+    # Tests that matching_user returns the matching user when the display name exists in the user_list.
+    def test_matching_user_matching_display_name_exists(self):
+        user_list = [
+            {"email": "user1@example.com", "name": "User 1"},
+            {"email": "user2@example.com", "name": "User 2"},
+            {"email": "user3@example.com", "name": "User 3"},
+        ]
+        ado_user = ADOAssignedUser(display_name="User 2", email="user2@example.co.uk")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertEqual(result, {"email": "user2@example.com", "name": "User 2"})
+
+    # Tests that matching_user returns the matching user when the email exists in another case in the user_list.
+    def test_matching_user_matching_email_exists_other_case(self):
+        user_list = [
+            {"email": "USER1@EXAMPLE.COM", "name": "USER 1"},
+            {"email": "USER2@EXAMPLE.COM", "name": "USER 2"},
+            {"email": "USER3@EXAMPLE.COM", "name": "USER 3"},
+        ]
+        ado_user = ADOAssignedUser(display_name="User Two", email="user2@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertEqual(result, {"email": "USER2@EXAMPLE.COM", "name": "USER 2"})
+
+    # Tests that matching_user returns the matching user when the display name exists in another case in the user_list.
+    def test_matching_user_matching_display_name_exists_other_case(self):
+        user_list = [
+            {"email": "USER1@EXAMPLE.COM", "name": "USER 1"},
+            {"email": "USER2@EXAMPLE.COM", "name": "USER 2"},
+            {"email": "USER3@EXAMPLE.COM", "name": "USER 3"},
+        ]
+        ado_user = ADOAssignedUser(display_name="User 2", email="user2@example.co.uk")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertEqual(result, {"email": "USER2@EXAMPLE.COM", "name": "USER 2"})
+
+    # Tests that matching_user returns None when the email does not exist in the user_list.
+    def test_matching_user_matching_email_does_not_exist(self):
+        user_list = [
+            {"email": "user1@example.com", "name": "User 1"},
+            {"email": "user2@example.com", "name": "User 2"},
+            {"email": "user3@example.com", "name": "User 3"},
+        ]
+        ado_user = ADOAssignedUser(display_name="User 4", email="user4@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user returns None when the user_list is empty.
+    def test_matching_user_user_list_empty(self):
+        user_list = []
+        ado_user = ADOAssignedUser(display_name="User 1", email="user1@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user returns None when the email is an empty string.
+    def test_matching_user_email_empty(self):
+        user_list = [
+            {"email": "user1@example.com", "name": "User 1"},
+            {"email": "user2@example.com", "name": "User 2"},
+            {"email": "user3@example.com", "name": "User 3"},
+        ]
+        ado_user = ADOAssignedUser(display_name="", email="")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user returns the user when the user_list contains only one user and the email matches that user's email.
+    def test_matching_user_user_list_contains_one_user_email_matches(self):
+        user_list = [
+            {"email": "user1@example.com", "name": "User 1"},
+        ]
+        ado_user = ADOAssignedUser(display_name="User 1", email="user1@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertEqual(result, {"email": "user1@example.com", "name": "User 1"})
+
+    # Tests that matching_user returns None when the user_list contains only one user and the email does not match that user's email.
+    def test_matching_user_user_list_contains_one_user_email_does_not_match(
+        self,
+    ):
+        user_list = [
+            {"email": "user1@example.com", "name": "User 1"},
+        ]
+        ado_user = ADOAssignedUser(display_name="User 2", email="user2@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user returns None when the ado_user is None.
+    def test_matching_user_ado_user_none(self):
+        user_list = [
+            {"email": "user1@example.com", "name": "User 1"},
+            {"email": "user2@example.com", "name": "User 2"},
+            {"email": "user3@example.com", "name": "User 3"},
+        ]
+        ado_user = None
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### **User description**
This pull request refactors the `matching_user` function to handle case-insensitive email and display name comparisons. Previously, the function only checked for exact matches, but now it uses the `lower()` method to compare the email and display name in a case-insensitive manner. This ensures that the function can correctly match users even if the case of the email or display name is different. The pull request also includes unit tests to verify the behavior of the function in different scenarios.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Refactored the `matching_user` function to handle case-insensitive comparisons for emails and display names using the `lower()` method.
- Added comprehensive unit tests to verify the behavior of the `matching_user` function in different scenarios, including matching with different cases, empty lists, and None values.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Refactor `matching_user` for case-insensitive comparisons</code></dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<li>Refactored <code>matching_user</code> function for case-insensitive comparisons.<br> <li> Utilized <code>lower()</code> method for email and display name.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/284/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sync.py</strong><dd><code>Add unit tests for `matching_user` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_sync.py

<li>Added unit tests for <code>matching_user</code> function.<br> <li> Tested case-insensitive email and display name matching.<br> <li> Verified behavior for various scenarios including empty lists and None <br>values.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/284/files#diff-dac5b229e36d3c4af2b553d8166f028111f08257c36f93dfecb2929b1a2d2cf0">+126/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information