### PR TITLE
feat(sync): remove unnecessary database locks for read operations

### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -143,9 +143,8 @@ def create_tag_if_not_existing(app: App, workspace: str, tag: str) -> str | None
     """
     with _TRACER.start_as_current_span("create_tag_if_not_existing"):
         # Check if the tag_gid is stored in the config table
-        with app.db_lock:
-            tag_config = app.config.get(doc_id=1)
-            tag_gid = tag_config.get("tag_gid") if tag_config else None
+        tag_config = app.config.get(doc_id=1)
+        tag_gid = tag_config.get("tag_gid") if tag_config else None
 
         if tag_gid:
             _LOGGER.info("tag_gid found in database for '%s'", tag)
@@ -448,8 +447,7 @@ def sync_project(app: App, project):
         )
 
     # Process any existing matched items that are no longer returned in the backlog (closed or removed).
-    with app.db_lock:
-        all_tasks = app.matches.all()
+    all_tasks = app.matches.all()
     processed_item_ids = set(item.target.id for item in ado_items.work_items)
     for wi in all_tasks:
         if wi["ado_id"] not in processed_item_ids:

--- a/ado_asana_sync/sync/task_item.py
+++ b/ado_asana_sync/sync/task_item.py
@@ -117,10 +117,9 @@ class TaskItem:
             None: If there is no matching item.
         """
         query = Query().ado_id == ado_id
-        with app.db_lock:
-            if app.matches.contains(query):
-                item = app.matches.search(query)
-                return cls(**item[0])
+        if app.matches.contains(query):
+            item = app.matches.search(query)
+            return cls(**item[0])
         return None
 
     @classmethod
@@ -146,10 +145,9 @@ class TaskItem:
         query = (task.ado_id == ado_id) | (task.asana_gid == asana_gid)
 
         # return the first matching item, or return None if not found.
-        with app.db_lock:
-            if app.matches.contains(query):
-                item = app.matches.search(query)
-                return cls(**item[0])
+        if app.matches.contains(query):
+            item = app.matches.search(query)
+            return cls(**item[0])
         return None
 
     def save(self, app: App) -> None:
@@ -176,10 +174,11 @@ class TaskItem:
             "updated_date": self.updated_date,
         }
         query = Query().ado_id == task_data["ado_id"]
-        with app.db_lock:
-            if app.matches.contains(query):
+        if app.matches.contains(query):
+            with app.db_lock:
                 app.matches.update(task_data, query)
-            else:
+        else:
+            with app.db_lock:
                 app.matches.insert(task_data)
 
     def is_current(self, app: App) -> bool:

--- a/tests/sync/test_task_item.py
+++ b/tests/sync/test_task_item.py
@@ -40,17 +40,13 @@ class TestTaskItem(unittest.TestCase):
     def test_returns_task_item_with_matching_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.db_lock = MagicMock()
 
-        with app.db_lock:
-            app.matches = MagicMock()
+        app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        with app.db_lock:
-            app.matches.contains.return_value = True
+        app.matches.contains.return_value = True
         # Mock the search method of the matches table to return a mock TaskItem object
-        with app.db_lock:
-            app.matches.search.return_value = [TEST_DB_ITEM_1]
+        app.matches.search.return_value = [TEST_DB_ITEM_1]
 
         # Call the find_by_ado_id method with a valid ADO ID
         result = TaskItem.find_by_ado_id(app, 1)
@@ -73,14 +69,11 @@ class TestTaskItem(unittest.TestCase):
     def test_returns_task_item_with_no_matching_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.db_lock = MagicMock()
 
-        with app.db_lock:
-            app.matches = MagicMock()
+        app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return False
-        with app.db_lock:
-            app.matches.contains.return_value = False
+        app.matches.contains.return_value = False
 
         # Call the find_by_ado_id method with a non-existing ADO ID
         result = TaskItem.find_by_ado_id(app, 1)
@@ -92,10 +85,8 @@ class TestTaskItem(unittest.TestCase):
     def test_returns_none_if_ado_id_and_asana_gid_are_none(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.db_lock = MagicMock()
 
-        with app.db_lock:
-            app.matches = MagicMock()
+        app.matches = MagicMock()
 
         # Call the search method with None for both ado_id and asana_gid
         result = TaskItem.search(app, None, None)
@@ -107,17 +98,13 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_valid_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.db_lock = MagicMock()
 
-        with app.db_lock:
-            app.matches = MagicMock()
+        app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        with app.db_lock:
-            app.matches.contains.return_value = True
+        app.matches.contains.return_value = True
         # Mock the search method of the matches table to return a mock TaskItem object
-        with app.db_lock:
-            app.matches.search.return_value = [TEST_DB_ITEM_1]
+        app.matches.search.return_value = [TEST_DB_ITEM_1]
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, ado_id=1)
@@ -128,17 +115,13 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_valid_asana_guid(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.db_lock = MagicMock()
 
-        with app.db_lock:
-            app.matches = MagicMock()
+        app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        with app.db_lock:
-            app.matches.contains.return_value = True
+        app.matches.contains.return_value = True
         # Mock the search method of the matches table to return a mock TaskItem object
-        with app.db_lock:
-            app.matches.search.return_value = [TEST_DB_ITEM_1]
+        app.matches.search.return_value = [TEST_DB_ITEM_1]
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, asana_gid="123456")
@@ -149,14 +132,11 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_invalid_ado_id(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.db_lock = MagicMock()
 
-        with app.db_lock:
-            app.matches = MagicMock()
+        app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        with app.db_lock:
-            app.matches.contains.return_value = False
+        app.matches.contains.return_value = False
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, ado_id=5)
@@ -167,14 +147,11 @@ class TestTaskItem(unittest.TestCase):
     def test_search_with_invalid_asana_guid(self):
         # Create a mock App instance
         app = MagicMock(App)
-        app.db_lock = MagicMock()
 
-        with app.db_lock:
-            app.matches = MagicMock()
+        app.matches = MagicMock()
 
         # Mock the contains method of the matches table to return True
-        with app.db_lock:
-            app.matches.contains.return_value = False
+        app.matches.contains.return_value = False
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, asana_gid="987654")


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Removed unnecessary database locks from read operations in `sync.py` and `task_item.py`, optimizing performance.
- Retained database locks only for write operations to ensure data integrity.
- Updated test cases in `test_task_item.py` to align with the changes in database locking logic, removing mock locks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Optimize database access by removing unnecessary locks</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<li>Removed database lock from read operations.<br> <li> Simplified logic for retrieving tag_gid and all_tasks.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/289/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>task_item.py</strong><dd><code>Refactor database locking to only lock on writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/task_item.py

<li>Removed database lock from read operations.<br> <li> Retained lock only for write operations.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/289/files#diff-0fd0b95374ef93889cff36010b72b44a77c0a57d693a2d3a99ad82917bcb89e6">+10/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_task_item.py</strong><dd><code>Update tests to reflect changes in database locking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_task_item.py

<li>Removed mock db_lock from test cases.<br> <li> Simplified test setup by removing unnecessary lock context.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/289/files#diff-960fbea415e87edb53e4658950b63a6a514be88b83eaea5906f3d7ff3b4b30da">+16/-39</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information