### PR TITLE
ci: update coverage configuration for SonarCloud integration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,4 @@ commands =
     poetry run pytest --cov=. --cov-report=xml --cov-config=tox.ini --cov-branch
 
 [coverage:run]
+relative_files = True


### PR DESCRIPTION
### **User description**
Fixes #291


___

### **PR Type**
configuration changes


___

### **Description**
- Added `relative_files = True` to the `[coverage:run]` section in `tox.ini` to fix the issue with SonarCloud coverage reporting.
- This change ensures that coverage paths are reported relative to the source, which is necessary for correct integration with SonarCloud.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tox.ini</strong><dd><code>Update coverage configuration to use relative file paths</code>&nbsp; </dd></summary>
<hr>

tox.ini

<li>Added <code>relative_files = True</code> under <code>[coverage:run]</code> section.<br> <li> This change affects how coverage paths are reported.<br>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/293/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information