### PR TITLE
fix(sync): use `completed` instead of `state` in create_asana_task


### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -703,7 +703,7 @@ def create_asana_task(app: App, asana_project: str, task: TaskItem, tag: str) ->
             "projects": [asana_project],
             "assignee": task.assigned_to,
             "tags": [tag],
-            "state": task.state in _CLOSED_STATES,
+            "completed": task.state in _CLOSED_STATES,
         },
     }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace payload key `state` with `completed`.

- Set `completed` for closed tasks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Use `completed` field for Asana tasks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<li>Changed Asana task payload key from <code>state</code> to <code>completed</code>.<br> <li> Set <code>completed</code> field based on closed task states.


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/340/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>