### PR TITLE
chore(ci): expand tox envs and refine GitHub Actions


### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
       - name: Test with pytest
-        run: poetry run tox
+        run: poetry run tox -e pytest
       - uses: actions/upload-artifact@v4
         with:
           name: test-output

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ parallel = true
 [testenv]
 # Base install used for pytest and tool runs
 allowlist_externals = poetry
+setenv =
+    PYTHONPATH = {toxinidir}
 commands =
     poetry install -v --no-interaction
 
@@ -16,7 +18,7 @@ commands =
 
 [testenv:flake8]
 description = Run flake8 linting
-commands = poetry run flake8 ado_asana_sync --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+commands = poetry run flake8 ado_asana_sync --count --max-complexity=10 --max-line-length=127 --statistics
 
 [testenv:mypy]
 description = Run static type checks

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,34 @@
 [tox]
-envlist = py310
-skipsdist = True
+envlist = pytest,flake8,mypy,bandit,pylint
+skipsdist = true
+parallel = true
 
 [testenv]
+# Base install used for pytest and tool runs
 allowlist_externals = poetry
 commands =
-    poetry install -v
+    poetry install -v --no-interaction
+
+[testenv:pytest]
+description = Run full pytest with coverage
+commands =
     poetry run pytest --cov=. --cov-report=xml --cov-config=tox.ini --cov-branch
 
+[testenv:flake8]
+description = Run flake8 linting
+commands = poetry run flake8 ado_asana_sync --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+[testenv:mypy]
+description = Run static type checks
+commands = poetry run mypy ado_asana_sync
+
+[testenv:bandit]
+description = Run security checks
+commands = poetry run bandit --recursive ado_asana_sync
+
+[testenv:pylint]
+description = Run pylint checks
+commands = poetry run pylint --recursive=true ado_asana_sync
+
 [coverage:run]
-relative_files = True
+relative_files = true


### PR DESCRIPTION
### **User description**
Revise the Tox configuration to include multiple testing environments and enhance the pytest command for better coverage reporting. This update also improves the installation process and adds linting and static analysis checks.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Expand tox envlist for linting and analysis

- Enable parallel test execution in tox

- Update CI to use tox -e pytest

- Standardize install flags and coverage config


___

### **Changes diagram**

```mermaid
flowchart LR
  A[".github/workflows/build.yml"] -- "runs tox -e pytest" --> B["tox.ini pytest env"]
  B -- "envlist updated" --> C["flake8, mypy, bandit, pylint configs"]
  B -- "parallel execution enabled" --> D["parallel=true"]
  B -- "install flags standardized" --> E["--no-interaction flag"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Use pytest environment in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

- Updated test step to `tox -e pytest`


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/366/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tox.ini</strong><dd><code>Enhance tox configurations with new envs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tox.ini

<li>Expanded <code>envlist</code> with pytest, linting, checks<br> <li> Enabled <code>parallel=true</code> for parallel runs<br> <li> Added flake8, mypy, bandit, pylint envs<br> <li> Updated install command with <code>--no-interaction</code>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/366/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449">+26/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>