### PR TITLE
fix(sync): simplify Asana pagination and add unit tests


### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -663,7 +663,7 @@ def get_asana_project_tasks(app: App, asana_project) -> list[dict]:
                 "assignee_status,num_subtasks,modified_at,workspace,due_on"
             ),
         }
-        api_response = api_instance.get_tasks(**api_params)
+        api_response = api_instance.get_tasks(api_params)
         return list(api_response)
     except ApiException as exception:
         _LOGGER.error(

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -663,7 +663,7 @@ def get_asana_project_tasks(app: App, asana_project) -> list[dict]:
                 "assignee_status,num_subtasks,modified_at,workspace,due_on"
             ),
         }
-        api_response = api_instance.get_tasks(api_params)
+        api_response = api_instance.get_tasks(**api_params)
         return list(api_response)
     except ApiException as exception:
         _LOGGER.error(

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -767,7 +767,7 @@ def get_asana_project_custom_fields(app: App, project_gid: str) -> list[dict]:
         _LOGGER.info("Fetching custom fields for project %s", project_gid)
         opts = {"limit": 100}
         api_response = api_instance.get_custom_field_settings_for_project(
-            project_gid, **opts
+            project_gid, opts
         )
         custom_fields = list(api_response)
         CUSTOM_FIELDS_CACHE[project_gid] = custom_fields

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -767,7 +767,7 @@ def get_asana_project_custom_fields(app: App, project_gid: str) -> list[dict]:
         _LOGGER.info("Fetching custom fields for project %s", project_gid)
         opts = {"limit": 100}
         api_response = api_instance.get_custom_field_settings_for_project(
-            project_gid, opts
+            project_gid, **opts
         )
         custom_fields = list(api_response)
         CUSTOM_FIELDS_CACHE[project_gid] = custom_fields

--- a/tests/sync/test_pagination.py
+++ b/tests/sync/test_pagination.py
@@ -1,0 +1,41 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ado_asana_sync.sync.app import App
+from ado_asana_sync.sync import sync
+from ado_asana_sync.sync.sync import (
+    get_asana_project_tasks,
+    get_asana_project_custom_fields,
+)
+
+
+class TestPaginationFunctions(unittest.TestCase):
+    def setUp(self):
+        self.app = MagicMock(App)
+        self.app.asana_client = MagicMock()
+        self.app.asana_page_size = 50
+
+    def test_get_asana_project_tasks_uses_iterator(self):
+        mock_api = MagicMock()
+        mock_api.get_tasks.return_value = iter([{"gid": "1"}, {"gid": "2"}])
+        with patch("ado_asana_sync.sync.sync.asana.TasksApi", return_value=mock_api):
+            tasks = get_asana_project_tasks(self.app, "proj1")
+        self.assertEqual(tasks, [{"gid": "1"}, {"gid": "2"}])
+        mock_api.get_tasks.assert_called_once()
+
+    def test_get_asana_project_custom_fields_uses_iterator(self):
+        sync.CUSTOM_FIELDS_CACHE.clear()
+        sync.CUSTOM_FIELDS_AVAILABLE = True
+        mock_api = MagicMock()
+        mock_api.get_custom_field_settings_for_project.return_value = iter([{"gid": "cf"}])
+        with patch(
+            "ado_asana_sync.sync.sync.asana.CustomFieldSettingsApi",
+            return_value=mock_api,
+        ):
+            fields = get_asana_project_custom_fields(self.app, "123")
+        self.assertEqual(fields, [{"gid": "cf"}])
+        mock_api.get_custom_field_settings_for_project.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sync/test_tag_functions.py
+++ b/tests/sync/test_tag_functions.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ado_asana_sync.sync.app import App
+from ado_asana_sync.sync.sync import (
+    create_tag_if_not_existing,
+    get_tag_by_name,
+    get_asana_task_tags,
+)
+from ado_asana_sync.sync.task_item import TaskItem
+
+
+class TestTagFunctions(unittest.TestCase):
+    def setUp(self):
+        self.app = MagicMock(App)
+        self.app.asana_client = MagicMock()
+        self.app.db_lock = MagicMock()
+        self.app.config = MagicMock()
+
+    def test_create_tag_returns_existing_config(self):
+        self.app.config.get.return_value = {"tag_gid": "111"}
+        tag = create_tag_if_not_existing(self.app, "ws", "tag")
+        self.assertEqual(tag, "111")
+        self.app.config.get.assert_called_once_with(doc_id=1)
+
+    def test_get_tag_by_name_found(self):
+        mock_api = MagicMock()
+        mock_api.get_tags.return_value = iter([{"name": "foo", "gid": "1"}])
+        with patch("ado_asana_sync.sync.sync.asana.TagsApi", return_value=mock_api):
+            tag = get_tag_by_name(self.app, "ws", "foo")
+        self.assertEqual(tag, {"name": "foo", "gid": "1"})
+
+    def test_get_asana_task_tags(self):
+        task = TaskItem(1, 1, "t", "Bug", "url", asana_gid="g")
+        mock_api = MagicMock()
+        mock_api.get_tags_for_task.return_value = iter([{"gid": "2"}])
+        with patch("ado_asana_sync.sync.sync.asana.TagsApi", return_value=mock_api):
+            tags = get_asana_task_tags(self.app, task)
+        self.assertEqual(tags, [{"gid": "2"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
## Summary
- simplify get_asana_project_tasks to rely on Asana's iterator
- simplify get_asana_project_custom_fields to rely on Asana's iterator
- add unit tests for pagination and tag utilities

## Testing
- `poetry run pytest -q`
- `poetry run pytest --cov=. --cov-report=term-missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68670a3e0970832f8ec78745e7ec2775


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Simplify Asana pagination using API iterators

- Remove manual pagination loops in sync functions

- Add unit tests for pagination utilities

- Add unit tests for tag utility functions


___

### **Changes diagram**

```mermaid
flowchart LR
  A["get_asana_project_tasks"] -- "calls" --> B["TasksApi.get_tasks"]
  B -- "returns iterator" --> C["list(iterator)"]
  D["get_asana_project_custom_fields"] -- "calls" --> E["CustomFieldSettingsApi.get_custom_field_settings_for_project"]
  E -- "returns iterator" --> F["list(iterator)"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Use Asana API iterator for pagination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<li>Removed manual pagination loops from project tasks<br> <li> Simplified get_asana_project_tasks to use iterator<br> <li> Simplified get_asana_project_custom_fields to use iterator<br> <li> Adjusted docstrings for brevity


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/367/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+16/-41</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pagination.py</strong><dd><code>Add pagination function tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_pagination.py

<li>Added tests for get_asana_project_tasks iterator behavior<br> <li> Added tests for get_asana_project_custom_fields iterator behavior<br> <li> Mocked TasksApi and CustomFieldSettingsApi responses


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/367/files#diff-5c4afb48e0878476024b155ff7997b06bc204240a018465d4fec8e14b2c897b1">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_tag_functions.py</strong><dd><code>Add tag utility tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_tag_functions.py

<li>Added tests for create_tag_if_not_existing function<br> <li> Added tests for get_tag_by_name and get_asana_task_tags<br> <li> Used MagicMock and patch for TagsApi


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/367/files#diff-3841ccf1951e23336ca705eebec32db5ec5146a8f492a2426732683e4d3d51fd">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>