### PR TITLE
feat(sync): log unmatched assigned user details


### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -358,6 +358,12 @@ def process_backlog_item(
 
     asana_matched_user = matching_user(asana_users, ado_assigned)
     if asana_matched_user is None and existing_match is None:
+        _LOGGER.info(
+            "%s:assigned user %s <%s> not found in Asana",
+            ado_task.fields[ADO_TITLE],
+            ado_assigned.display_name,
+            ado_assigned.email,
+        )
         return
 
     if existing_match is None:


### PR DESCRIPTION
### **User description**
## Summary
- log a message when an assigned user can't be matched to an Asana user
- test unmatched user logging

## Testing
- `poetry run tox -q` *(fails: flake8, mypy, bandit, pylint)*

------
https://chatgpt.com/codex/tasks/task_e_68671bfc979c832fb8d2d964f7a275da


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Log info when assigned user not found in Asana

- Include assigned user's display name and email

- Add unit test for unmatched user logging

- Import patch for mocking logger in tests


___

### **Changes diagram**

```mermaid
flowchart LR
  A["process_backlog_item"] -- "no matching user" --> B["_LOGGER.info log unmatched user"]
  B -- "return" --> C["end processing"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Log unmatched assigned user details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<li>Add info log for unmatched assigned user<br> <li> Include user's display_name and email


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/369/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sync.py</strong><dd><code>Add logging test for unmatched user</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_sync.py

<li>Import patch from unittest.mock<br> <li> Add TestProcessBacklogItemLogging class<br> <li> Add test for unmatched user logging


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/369/files#diff-dac5b229e36d3c4af2b553d8166f028111f08257c36f93dfecb2929b1a2d2cf0">+34/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>