### PR TITLE
Update coverage configuration in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,5 @@ commands = poetry run pylint --recursive=true ado_asana_sync
 
 [coverage:run]
 relative_files = true
+omit =
+    tests/*


### PR DESCRIPTION
Revise the coverage settings in the tox configuration to exclude test files, enhancing the accuracy of coverage reports.