### PR TITLE
feat(github-actions): add Claude PR Assistant workflow for @claude mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,47 @@
+# https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          timeout_minutes: "60"
+          # mode: tag  # Default: responds to @claude mentions
+          # Optional: Restrict network access to specific domains only
+          # experimental_allowed_domains: |
+          #   .anthropic.com
+          #   .github.com
+          #   api.github.com
+          #   .githubusercontent.com
+          #   bun.sh
+          #   registry.npmjs.org
+          #   .blob.core.windows.net


### PR DESCRIPTION
### **User description**
Introduce a GitHub Actions workflow for the Claude PR Assistant to automate responses to specific comments and reviews. This workflow triggers on various events, allowing for enhanced interaction with issues and pull requests.


___

### **PR Type**
Enhancement, Other


___

### **Description**
Add Claude PR Assistant GitHub Actions workflow
Trigger on comments, reviews, issues with @claude
Configure minimal permissions and checkout
Use anthropics/claude-code-action with timeout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue/PR Events (@claude)"] -- "triggers" --> B["GitHub Actions Workflow"]
  B -- "runs" --> C["Checkout repository"]
  C -- "uses" --> D["anthropics/claude-code-action@beta"]
  D -- "responds to" --> E["Comments/Reviews/Issues"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Github actions</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Introduce Claude PR Assistant GitHub workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Add workflow triggering on comments, reviews, issues<br> <li> Filter events for bodies containing <code>@claude</code><br> <li> Set permissions and checkout step<br> <li> Configure <code>anthropics/claude-code-action@beta</code> with OAuth token and <br>timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/388/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

