### PR TITLE
chore(workflow): expand Claude PR Action optional configuration and triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,13 +35,23 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           timeout_minutes: "60"
-          # mode: tag  # Default: responds to @claude mentions
-          # Optional: Restrict network access to specific domains only
-          # experimental_allowed_domains: |
-          #   .anthropic.com
-          #   .github.com
-          #   api.github.com
-          #   .githubusercontent.com
-          #   bun.sh
-          #   registry.npmjs.org
-          #   .blob.core.windows.net
+          # Optional: set execution mode (default: tag)
+          # mode: "tag"
+          # Optional: add custom trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+          # Optional: add assignee trigger for issues
+          assignee_trigger: "claude"
+          # Optional: add label trigger for issues
+          label_trigger: "claude"
+          # Optional: add custom environment variables (YAML format)
+          # claude_env: |
+          #   NODE_ENV: test
+          #   DEBUG: true
+          #   API_URL: https://api.example.com
+          # Optional: limit the number of conversation turns
+          # max_turns: "5"
+          # Optional: grant additional permissions (requires corresponding GitHub token permissions)
+          # additional_permissions: |
+          #   actions: read
+          # Optional: allow bot users to trigger the action
+          # allowed_bots: "dependabot[bot],renovate[bot]"


### PR DESCRIPTION
### **User description**
Introduce a GitHub Actions workflow for the Claude PR Assistant, including optional configuration comments for customization.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
Expand Claude Action configuration options in workflow
Add issue triggers: assignee and label
Clarify optional settings with commented examples
Improve guidance on env, perms, bots, limits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WF["GitHub Actions workflow .github/workflows/claude.yml"] -- "Add optional config comments" --> CLAUDE["Claude PR Action"]
  WF -- "Enable issue triggers" --> TRIGGERS["assignee_trigger, label_trigger"]
  WF -- "Document advanced options" --> OPTIONS["env vars, max_turns, permissions, allowed_bots"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Expand optional configuration for Claude Action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Add commented examples for mode and trigger phrase<br> <li> Introduce assignee and label issue triggers<br> <li> Document env vars, max_turns, permissions, allowed_bots<br> <li> Replace/expand previous allowed domains examples</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/389/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+20/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

