### PR TITLE
fix(github-actions): use CLAUDE_CODE_OAUTH_TOKEN in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -74,7 +74,7 @@ jobs:
       - uses: anthropics/claude-code-action@beta
         with:
           mode: agent
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           override_prompt: |
             Check for outdated dependencies and security vulnerabilities.
             Create an issue if any critical problems are found.

--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,4 @@ venv.bak/
 # Other
 .aider*
 *.ignore*
-data/appdata.json
-data/projects.json
+data/


### PR DESCRIPTION
### **User description**
Revise the API key reference for agent mode in the Claude workflow and streamline the .gitignore to exclude all data files.


___

### **PR Type**
Enhancement


___

### **Description**
- Update Claude workflow API key reference

- Switch to `CLAUDE_CODE_OAUTH_TOKEN` secret

- Maintain agent mode configuration

- Security-oriented prompt remains unchanged


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WF["claude.yml workflow"] -- "update secret key" --> KEY["anthropic_api_key uses CLAUDE_CODE_OAUTH_TOKEN"]
  WF -- "retain agent mode and prompt" --> AGENT["Agent mode config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Github actions</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Update workflow to new OAuth token secret</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Replace <code>ANTRHOPIC_API_KEY</code> secret with <code>CLAUDE_CODE_OAUTH_TOKEN</code><br> <li> Keep <code>mode: agent</code> and override prompt intact</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/391/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

