### PR TITLE
chore(workflow): disable schedule and gate agent to dispatch

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
   # Agent Mode - Automation for workflow_dispatch and schedule events
   agent-mode-scheduled-task:
     # Only works with workflow_dispatch or schedule events
-    if: github.event_name == 'workflow_dispatch'
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### **User description**
Commented out the schedule event in the Claude workflow to prevent it from triggering automatically.


___

### **PR Type**
Enhancement


___

### **Description**
- Disable scheduled runs in Claude workflow

- Restrict agent job to manual dispatch

- Preserve other event triggers unchanged

- Minor workflow logic refinement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["claude.yml workflow"] -- "schedule disabled" --> B["No weekly cron"]
  A -- "agent-mode-scheduled-task" --> C["if: workflow_dispatch only"]
  A -- "other events unchanged" --> D["issue/pr comments, reviews"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Disable cron and gate agent job to dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Comment out <code>schedule</code> cron trigger.<br> <li> Add <code>if: github.event_name == 'workflow_dispatch'</code> to agent job.<br> <li> Keep other event triggers intact.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/394/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

