### PR TITLE
fix(sync): prevent PR ID/title mismatch and cleanup corrupted PR records

### DIFF
--- a/ado_asana_sync/sync/app.py
+++ b/ado_asana_sync/sync/app.py
@@ -180,6 +180,9 @@ class App:
         # Sync projects from JSON on startup
         self._sync_projects_from_json()
 
+        # Clean up any corrupted PR records from previous runs
+        self._cleanup_corrupted_pr_data()
+
     def _sync_projects_from_json(self) -> None:
         """
         Sync projects from projects.json to the database.
@@ -203,6 +206,21 @@ class App:
 
         except Exception as e:
             _LOGGER.error("Failed to sync projects from JSON: %s", e)
+
+    def _cleanup_corrupted_pr_data(self) -> None:
+        """
+        Clean up corrupted PR data during application startup.
+        """
+        try:
+            from .pull_request_item import PullRequestItem
+
+            if self.pr_matches is not None:
+                cleaned_count = PullRequestItem.cleanup_all_corrupted_records(self)
+                if cleaned_count > 0:
+                    _LOGGER.info("Startup cleanup removed %d corrupted PR records", cleaned_count)
+
+        except Exception as e:
+            _LOGGER.error("Failed to cleanup corrupted PR data: %s", e)
 
     def close(self) -> None:
         """

--- a/ado_asana_sync/sync/pull_request_item.py
+++ b/ado_asana_sync/sync/pull_request_item.py
@@ -61,6 +61,17 @@ class PullRequestItem:
         self.updated_date = updated_date
         self.review_status = review_status
 
+        # Validate data consistency to catch potential corruption early
+        if not self.validate_data_consistency():
+            # This is a critical error that indicates data corruption
+            from ado_asana_sync.utils.logging_tracing import setup_logging_and_tracing
+            logger, _ = setup_logging_and_tracing(__name__)
+            logger.error(
+                "Data consistency validation failed for PR item: ado_pr_id=%s, url=%s, title='%s'. "
+                "This indicates potential data corruption where PR ID and URL don't match.",
+                self.ado_pr_id, self.url, self.title
+            )
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, PullRequestItem):
             return False
@@ -111,6 +122,45 @@ class PullRequestItem:
         return f'<a href="{self.url}">Pull Request {self.ado_pr_id}</a>: {escape(self.title)}'
 
     @classmethod
+    def _create_search_query(
+        cls,
+        ado_pr_id: Optional[int] = None,
+        reviewer_gid: Optional[str] = None,
+        asana_gid: Optional[str] = None,
+    ):
+        """Create a query function for database search."""
+        def query_func(record):
+            # Check for PR ID and reviewer GID combination first (most specific)
+            if ado_pr_id is not None and reviewer_gid is not None:
+                return (record.get("ado_pr_id") == ado_pr_id and
+                        record.get("reviewer_gid") == reviewer_gid)
+
+            # Check individual conditions
+            if ado_pr_id is not None and record.get("ado_pr_id") == ado_pr_id:
+                return True
+            if reviewer_gid is not None and record.get("reviewer_gid") == reviewer_gid:
+                return True
+            if asana_gid is not None and record.get("asana_gid") == asana_gid:
+                return True
+
+            return False
+        return query_func
+
+    @classmethod
+    def _validate_search_result(cls, pr_item, ado_pr_id: Optional[int], item_data: dict) -> bool:
+        """Validate that search result matches expected criteria."""
+        if ado_pr_id is not None and pr_item.ado_pr_id != ado_pr_id:
+            from ado_asana_sync.utils.logging_tracing import setup_logging_and_tracing
+            logger, _ = setup_logging_and_tracing(__name__)
+            logger.warning(
+                "Database corruption detected: searched for PR ID %s but got item with ID %s. "
+                "This could cause title/ID mismatches. Item data: %s",
+                ado_pr_id, pr_item.ado_pr_id, item_data
+            )
+            return False
+        return True
+
+    @classmethod
     def search(
         cls,
         app: App,
@@ -133,31 +183,20 @@ class PullRequestItem:
         if ado_pr_id is None and reviewer_gid is None and asana_gid is None:
             return None
 
-        # Generate the query function based on the input.
-        def query_func(record):
-            # Check for PR ID and reviewer GID combination
-            if ado_pr_id is not None and reviewer_gid is not None:
-                if (record.get("ado_pr_id") == ado_pr_id and
-                        record.get("reviewer_gid") == reviewer_gid):
-                    return True
+        query_func = cls._create_search_query(ado_pr_id, reviewer_gid, asana_gid)
 
-            # Check individual conditions
-            if ado_pr_id is not None and record.get("ado_pr_id") == ado_pr_id:
-                return True
-            if reviewer_gid is not None and record.get("reviewer_gid") == reviewer_gid:
-                return True
-            if asana_gid is not None and record.get("asana_gid") == asana_gid:
-                return True
-
-            return False
-
-        # return the first matching item, or return None if not found.
         if app.pr_matches and app.pr_matches.contains(query_func):
             items = app.pr_matches.search(query_func)
             if items:
                 # Remove doc_id before creating PullRequestItem
                 item_data = {k: v for k, v in items[0].items() if k != 'doc_id'}
-                return cls(**item_data)
+                pr_item = cls(**item_data)
+
+                # Validate search result for corruption
+                if not cls._validate_search_result(pr_item, ado_pr_id, item_data):
+                    return None  # Don't return corrupted data
+
+                return pr_item
         return None
 
     def save(self, app: App) -> None:
@@ -170,6 +209,16 @@ class PullRequestItem:
         Returns:
             None
         """
+        # Validate data consistency before saving
+        if not self.validate_data_consistency():
+            from ado_asana_sync.utils.logging_tracing import setup_logging_and_tracing
+            logger, _ = setup_logging_and_tracing(__name__)
+            logger.error(
+                "Refusing to save PR item with inconsistent data: ado_pr_id=%s, url=%s, title='%s'",
+                self.ado_pr_id, self.url, self.title
+            )
+            return
+
         pr_data = {
             "ado_pr_id": self.ado_pr_id,
             "ado_repository_id": self.ado_repository_id,
@@ -194,12 +243,138 @@ class PullRequestItem:
             raise ValueError("app.pr_matches is None")
         if app.db_lock is None:
             raise ValueError("app.db_lock is None")
-        if app.pr_matches.contains(unique_query_func):
-            with app.db_lock:
+
+        # Use a larger critical section to ensure atomicity
+        with app.db_lock:
+            # Clean up any corrupted records for this PR/reviewer combination first
+            self._cleanup_corrupted_records(app, pr_data)
+
+            # Now save the current record
+            if app.pr_matches.contains(unique_query_func):
                 app.pr_matches.update(pr_data, unique_query_func)
-        else:
-            with app.db_lock:
+            else:
                 app.pr_matches.insert(pr_data)
+
+    def _cleanup_corrupted_records(self, app: App, current_pr_data: dict) -> None:
+        """Clean up corrupted records that don't match current data consistency."""
+        if app.pr_matches is None:
+            return
+
+        # Find all records for this PR ID
+        def pr_query_func(record):
+            return record.get("ado_pr_id") == current_pr_data["ado_pr_id"]
+
+        matching_records = app.pr_matches.search(pr_query_func)
+
+        # Handle case where matching_records might be None or empty, or a mock
+        if not matching_records:
+            return
+
+        # Handle mock objects in tests
+        try:
+            iter(matching_records)
+        except TypeError:
+            # If it's not iterable (e.g., a Mock), just return
+            return
+
+        corrupted_record_count = 0
+        for record in matching_records:
+            if self._should_remove_record(record, current_pr_data):
+                if self._remove_corrupted_record(app, record):
+                    corrupted_record_count += 1
+
+        if corrupted_record_count > 0:
+            from ado_asana_sync.utils.logging_tracing import setup_logging_and_tracing
+            logger, _ = setup_logging_and_tracing(__name__)
+            logger.info(
+                "Cleaned up %d corrupted PR records for PR ID %s",
+                corrupted_record_count, current_pr_data["ado_pr_id"]
+            )
+
+    def _should_remove_record(self, record: dict, current_pr_data: dict) -> bool:
+        """Check if a record should be removed due to corruption."""
+        # Skip the record we're about to save
+        if record.get("reviewer_gid") == current_pr_data["reviewer_gid"]:
+            return False
+
+        try:
+            # Check if this record has consistent data
+            clean_record = {k: v for k, v in record.items() if k != 'doc_id'}
+            temp_item = PullRequestItem(**clean_record)
+            return not temp_item.validate_data_consistency()
+        except Exception:
+            # If we can't even create the object, it's definitely corrupted
+            return True
+
+    def _remove_corrupted_record(self, app: App, record: dict) -> bool:
+        """Remove a corrupted record from the database."""
+        try:
+            def delete_query_func(r):
+                return (r.get("ado_pr_id") == record.get("ado_pr_id") and
+                        r.get("reviewer_gid") == record.get("reviewer_gid"))
+
+            app.pr_matches.remove(delete_query_func)
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def cleanup_all_corrupted_records(cls, app: App) -> int:
+        """
+        Clean up all corrupted PR records in the database.
+
+        This should be called during application startup to remove any existing corrupted data.
+
+        Args:
+            app (App): The App instance.
+
+        Returns:
+            int: Number of corrupted records cleaned up.
+        """
+        if app.pr_matches is None:
+            return 0
+
+        all_records = app.pr_matches.all()
+        corrupted_count = 0
+
+        if app.db_lock is None:
+            raise ValueError("app.db_lock is None")
+
+        with app.db_lock:
+            for record in all_records:
+                if cls._is_record_corrupted(record):
+                    if cls._remove_corrupted_record_static(app, record):
+                        corrupted_count += 1
+
+        if corrupted_count > 0:
+            from ado_asana_sync.utils.logging_tracing import setup_logging_and_tracing
+            logger, _ = setup_logging_and_tracing(__name__)
+            logger.info("Cleaned up %d corrupted PR records during startup", corrupted_count)
+
+        return corrupted_count
+
+    @classmethod
+    def _is_record_corrupted(cls, record: dict) -> bool:
+        """Check if a database record is corrupted."""
+        try:
+            clean_record = {k: v for k, v in record.items() if k != 'doc_id'}
+            temp_item = cls(**clean_record)
+            return not temp_item.validate_data_consistency()
+        except Exception:
+            return True
+
+    @classmethod
+    def _remove_corrupted_record_static(cls, app: App, record: dict) -> bool:
+        """Remove a corrupted record from the database (static version)."""
+        try:
+            def delete_query_func(r):
+                return (r.get("ado_pr_id") == record.get("ado_pr_id") and
+                        r.get("reviewer_gid") == record.get("reviewer_gid"))
+
+            app.pr_matches.remove(delete_query_func)
+            return True
+        except Exception:
+            return False
 
     def is_current(self, app: App, ado_pr, reviewer=None) -> bool:
         """
@@ -237,5 +412,33 @@ class PullRequestItem:
             current_review_status = extract_reviewer_vote(reviewer)
             if current_review_status != self.review_status:
                 return False
+
+        return True
+
+    def validate_data_consistency(self) -> bool:
+        """
+        Validate that the PR item's data is internally consistent.
+
+        Specifically checks that the URL contains the same PR ID as ado_pr_id,
+        which helps detect data corruption where PR ID and title don't match.
+
+        Returns:
+            bool: True if data is consistent, False otherwise.
+        """
+        if not self.url or not self.ado_pr_id:
+            return True  # Can't validate without URL or ID
+
+        # Extract PR ID from URL
+        url_parts = self.url.split('/')
+        try:
+            # URL format: .../pullrequest/{pr_id}
+            if 'pullrequest' in url_parts:
+                pr_index = url_parts.index('pullrequest')
+                if pr_index + 1 < len(url_parts):
+                    url_pr_id = int(url_parts[pr_index + 1])
+                    return url_pr_id == self.ado_pr_id
+        except (ValueError, IndexError):
+            # If we can't parse the URL, assume it's valid
+            return True
 
         return True

--- a/tests/sync/test_pr_id_title_mismatch.py
+++ b/tests/sync/test_pr_id_title_mismatch.py
@@ -1,0 +1,493 @@
+"""Tests to reproduce and fix PR ID and title mismatch issue.
+
+This test suite addresses issue where PR tasks are created with mismatched
+ID and title combinations, e.g., "Pull Request 123: test PR" but with 
+link to PR 456 instead of PR 123.
+"""
+
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+from threading import Thread
+import time
+
+from ado_asana_sync.sync.pull_request_sync import (
+    process_pull_request,
+    create_new_pr_reviewer_task,
+    update_existing_pr_reviewer_task,
+)
+from ado_asana_sync.sync.app import App
+from ado_asana_sync.sync.pull_request_item import PullRequestItem
+
+
+class TestPRIdTitleMismatch(unittest.TestCase):
+    """Test cases to reproduce and fix PR ID/title mismatch issues."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_app = Mock(spec=App)
+        self.mock_app.ado_git_client = Mock()
+        self.mock_app.pr_matches = Mock()
+        self.mock_app.db_lock = Mock()
+        self.mock_app.db_lock.__enter__ = Mock(return_value=self.mock_app.db_lock)
+        self.mock_app.db_lock.__exit__ = Mock(return_value=None)
+        self.mock_app.asana_tag_gid = "test-tag-gid"
+        self.mock_app.ado_url = "https://dev.azure.com/test"
+        self.mock_app.asana_workspace_name = "test-workspace"
+        self.mock_app.asana_client = Mock()
+
+        self.mock_repository = Mock()
+        self.mock_repository.id = "repo-456"
+        self.mock_repository.name = "test-repo"
+        self.mock_repository.project = Mock()
+        self.mock_repository.project.name = "Test Project"
+
+    def test_pr_item_preserves_original_data_on_creation(self):
+        """Test that PullRequestItem preserves original PR data correctly."""
+        # Create a PullRequestItem with specific data
+        pr_item = PullRequestItem(
+            ado_pr_id=100,
+            ado_repository_id="repo-123",
+            title="test PR",
+            status="active",
+            url="https://dev.azure.com/test/project/_git/repo/pullrequest/100",
+            reviewer_gid="reviewer-gid-1",
+            reviewer_name="Test Reviewer"
+        )
+
+        # Verify the asana_title combines the correct ID and title
+        expected_title = "Pull Request 100: test PR (Test Reviewer)"
+        self.assertEqual(pr_item.asana_title, expected_title)
+        self.assertEqual(pr_item.ado_pr_id, 100)
+        self.assertEqual(pr_item.title, "test PR")
+
+    def test_multiple_pr_items_maintain_separate_state(self):
+        """Test that multiple PullRequestItem objects maintain separate state."""
+        # Create two different PR items that simulate the reported issue
+        pr_item_a = PullRequestItem(
+            ado_pr_id=100,
+            ado_repository_id="repo-123",
+            title="test PR",
+            status="active",
+            url="https://dev.azure.com/test/project/_git/repo/pullrequest/100",
+            reviewer_gid="reviewer-gid-1",
+            reviewer_name="Reviewer A"
+        )
+
+        pr_item_b = PullRequestItem(
+            ado_pr_id=123,
+            ado_repository_id="repo-456",
+            title="another test pr",
+            status="active",
+            url="https://dev.azure.com/test/project/_git/repo/pullrequest/123",
+            reviewer_gid="reviewer-gid-2",
+            reviewer_name="Reviewer B"
+        )
+
+        # Verify each item maintains its own correct data
+        self.assertEqual(pr_item_a.asana_title, "Pull Request 100: test PR (Reviewer A)")
+        self.assertEqual(pr_item_b.asana_title, "Pull Request 123: another test pr (Reviewer B)")
+
+        # Verify URLs are correct
+        self.assertIn("pullrequest/100", pr_item_a.url)
+        self.assertIn("pullrequest/123", pr_item_b.url)
+
+    def test_database_record_corruption_detection(self):
+        """Test detection of corrupted database records where ID and title don't match."""
+        # Test case 1: URL and PR ID match (this should be valid)
+        valid_record = {
+            "ado_pr_id": 123,
+            "ado_repository_id": "repo-456",
+            "title": "test PR",
+            "status": "active",
+            "url": "https://dev.azure.com/test/project/_git/repo/pullrequest/123",  # URL matches ID
+            "reviewer_gid": "reviewer-gid-1",
+            "reviewer_name": "Test Reviewer"
+        }
+
+        valid_pr_item = PullRequestItem(**valid_record)
+        self.assertTrue(valid_pr_item.validate_data_consistency())
+
+        # Test case 2: URL and PR ID don't match (this indicates corruption)
+        corrupted_record = {
+            "ado_pr_id": 123,  # This ID
+            "ado_repository_id": "repo-456",
+            "title": "test PR",  # But this title from a different PR
+            "status": "active",
+            "url": "https://dev.azure.com/test/project/_git/repo/pullrequest/100",  # URL points to different PR!
+            "reviewer_gid": "reviewer-gid-1",
+            "reviewer_name": "Test Reviewer"
+        }
+
+        corrupted_pr_item = PullRequestItem(**corrupted_record)
+        self.assertFalse(corrupted_pr_item.validate_data_consistency())
+
+        # This would create the problematic title: "Pull Request 123: test PR"
+        # but the URL points to PR 100, indicating data corruption
+        problematic_title = corrupted_pr_item.asana_title
+        self.assertEqual(problematic_title, "Pull Request 123: test PR (Test Reviewer)")
+        self.assertIn("pullrequest/100", corrupted_pr_item.url)  # URL doesn't match ID
+
+    @patch('ado_asana_sync.sync.pull_request_sync.get_asana_task')
+    @patch('ado_asana_sync.sync.pull_request_sync.update_asana_pr_task')
+    @patch('ado_asana_sync.sync.pull_request_sync.iso8601_utc')
+    def test_title_update_doesnt_corrupt_other_items(self, mock_iso8601, mock_update_task, mock_get_task):
+        """Test that updating one PR's title doesn't affect other PR items."""
+        mock_iso8601.return_value = "2023-12-01T10:00:00Z"
+        mock_get_task.return_value = {"modified_at": "2023-12-01T09:00:00Z"}
+
+        # Create first PR item
+        pr_item_1 = PullRequestItem(
+            ado_pr_id=100,
+            ado_repository_id="repo-123",
+            title="original title",
+            status="active",
+            url="https://dev.azure.com/test/project/_git/repo/pullrequest/100",
+            reviewer_gid="reviewer-gid-1",
+            reviewer_name="Reviewer 1",
+            asana_gid="asana-task-1"
+        )
+
+        # Create second PR item
+        pr_item_2 = PullRequestItem(
+            ado_pr_id=123,
+            ado_repository_id="repo-456",
+            title="different title",
+            status="active",
+            url="https://dev.azure.com/test/project/_git/repo/pullrequest/123",
+            reviewer_gid="reviewer-gid-2",
+            reviewer_name="Reviewer 2",
+            asana_gid="asana-task-2"
+        )
+
+        # Mock ADO PR objects with updated titles
+        mock_pr_1 = Mock()
+        mock_pr_1.pull_request_id = 100
+        mock_pr_1.title = "updated title for PR 100"
+        mock_pr_1.status = "active"
+
+        mock_pr_2 = Mock()
+        mock_pr_2.pull_request_id = 123
+        mock_pr_2.title = "updated title for PR 123"
+        mock_pr_2.status = "active"
+
+        mock_reviewer = Mock()
+        mock_reviewer.vote = "waiting_for_author"
+        mock_asana_user = {"gid": "user-123", "name": "Test User"}
+
+        # Update first PR item
+        pr_item_1.is_current = Mock(return_value=False)
+        update_existing_pr_reviewer_task(
+            self.mock_app, mock_pr_1, self.mock_repository, mock_reviewer,
+            pr_item_1, mock_asana_user, "project-456"
+        )
+
+        # Update second PR item
+        pr_item_2.is_current = Mock(return_value=False)
+        update_existing_pr_reviewer_task(
+            self.mock_app, mock_pr_2, self.mock_repository, mock_reviewer,
+            pr_item_2, mock_asana_user, "project-456"
+        )
+
+        # Verify each item has the correct title and ID combination
+        self.assertEqual(pr_item_1.ado_pr_id, 100)
+        self.assertEqual(pr_item_1.title, "updated title for PR 100")
+        self.assertEqual(pr_item_1.asana_title, "Pull Request 100: updated title for PR 100 (Reviewer 1)")
+
+        self.assertEqual(pr_item_2.ado_pr_id, 123)
+        self.assertEqual(pr_item_2.title, "updated title for PR 123")
+        self.assertEqual(pr_item_2.asana_title, "Pull Request 123: updated title for PR 123 (Reviewer 2)")
+
+    def test_database_search_returns_correct_pr_item(self):
+        """Test that database search returns the correct PR item for a given PR ID and reviewer."""
+        # Mock database search results that could be problematic
+        mock_search_results = [
+            {
+                "ado_pr_id": 100,
+                "ado_repository_id": "repo-123",
+                "title": "test PR",
+                "status": "active",
+                "url": "https://dev.azure.com/test/project/_git/repo/pullrequest/100",
+                "reviewer_gid": "reviewer-gid-1",
+                "reviewer_name": "Test Reviewer",
+                "asana_gid": "asana-task-100"
+            }
+        ]
+
+        self.mock_app.pr_matches.contains.return_value = True
+        self.mock_app.pr_matches.search.return_value = mock_search_results
+
+        # Search for specific PR and reviewer combination
+        result = PullRequestItem.search(
+            self.mock_app,
+            ado_pr_id=100,
+            reviewer_gid="reviewer-gid-1"
+        )
+
+        # Verify we get the correct PR item
+        self.assertIsNotNone(result)
+        self.assertEqual(result.ado_pr_id, 100)
+        self.assertEqual(result.title, "test PR")
+        self.assertEqual(result.reviewer_gid, "reviewer-gid-1")
+        self.assertEqual(result.asana_title, "Pull Request 100: test PR (Test Reviewer)")
+
+    def test_database_search_rejects_corrupted_data(self):
+        """Test that database search rejects corrupted records."""
+        # Mock database search results that return wrong PR ID
+        corrupted_search_results = [
+            {
+                "ado_pr_id": 999,  # Wrong PR ID!
+                "ado_repository_id": "repo-123",
+                "title": "test PR",
+                "status": "active",
+                "url": "https://dev.azure.com/test/project/_git/repo/pullrequest/999",
+                "reviewer_gid": "reviewer-gid-1",
+                "reviewer_name": "Test Reviewer",
+                "asana_gid": "asana-task-999"
+            }
+        ]
+
+        self.mock_app.pr_matches.contains.return_value = True
+        self.mock_app.pr_matches.search.return_value = corrupted_search_results
+
+        # Search for specific PR ID but get back wrong data
+        result = PullRequestItem.search(
+            self.mock_app,
+            ado_pr_id=100,  # Looking for PR 100
+            reviewer_gid="reviewer-gid-1"
+        )
+
+        # Should return None because the returned data is corrupted
+        self.assertIsNone(result)
+
+    def test_cross_project_contamination_prevention(self):
+        """Test that PR items from different projects don't contaminate each other."""
+        # This is a simpler test that verifies PR items are independent
+        # Create two PR items from different projects
+        pr_item_a = PullRequestItem(
+            ado_pr_id=100,
+            ado_repository_id="project-a-repo",
+            title="test PR",
+            status="active",
+            url="https://dev.azure.com/test/projectA/_git/repo/pullrequest/100",
+            reviewer_gid="reviewer-gid-1",
+            reviewer_name="Reviewer A"
+        )
+
+        pr_item_b = PullRequestItem(
+            ado_pr_id=123,
+            ado_repository_id="project-b-repo",
+            title="another test pr",
+            status="active",
+            url="https://dev.azure.com/test/projectB/_git/repo/pullrequest/123",
+            reviewer_gid="reviewer-gid-2",
+            reviewer_name="Reviewer B"
+        )
+
+        # Verify that each item maintains its correct data independently
+        self.assertEqual(pr_item_a.ado_pr_id, 100)
+        self.assertEqual(pr_item_a.title, "test PR")
+        self.assertEqual(pr_item_a.asana_title, "Pull Request 100: test PR (Reviewer A)")
+
+        self.assertEqual(pr_item_b.ado_pr_id, 123)
+        self.assertEqual(pr_item_b.title, "another test pr")
+        self.assertEqual(pr_item_b.asana_title, "Pull Request 123: another test pr (Reviewer B)")
+
+        # Most importantly, verify there's no cross-contamination
+        self.assertNotEqual(pr_item_b.ado_pr_id, 100)  # Should not have Project A's ID
+        self.assertNotEqual(pr_item_b.title, "test PR")  # Should not have Project A's title
+        self.assertNotEqual(pr_item_a.ado_pr_id, 123)  # Should not have Project B's ID
+        self.assertNotEqual(pr_item_a.title, "another test pr")  # Should not have Project B's title
+
+    def test_concurrent_pr_processing_isolation(self):
+        """Test that concurrent processing of different PRs maintains data isolation."""
+        # This test simulates concurrent access that could lead to data races
+        results = {}
+        errors = []
+
+        def process_pr_worker(pr_id, title, worker_id):
+            """Worker function to simulate concurrent PR processing."""
+            try:
+                pr_item = PullRequestItem(
+                    ado_pr_id=pr_id,
+                    ado_repository_id=f"repo-{pr_id}",
+                    title=title,
+                    status="active",
+                    url=f"https://dev.azure.com/test/project/_git/repo/pullrequest/{pr_id}",
+                    reviewer_gid=f"reviewer-{worker_id}",
+                    reviewer_name=f"Reviewer {worker_id}"
+                )
+
+                # Simulate some processing time
+                time.sleep(0.01)
+
+                # Store results for verification
+                results[worker_id] = {
+                    'pr_id': pr_item.ado_pr_id,
+                    'title': pr_item.title,
+                    'asana_title': pr_item.asana_title,
+                    'url': pr_item.url
+                }
+
+            except Exception as e:
+                errors.append(f"Worker {worker_id}: {e}")
+
+        # Create threads to simulate concurrent processing
+        threads = []
+        test_data = [
+            (100, "test PR", "worker1"),
+            (123, "another test pr", "worker2"),
+            (456, "third pr title", "worker3"),
+            (789, "fourth pr title", "worker4")
+        ]
+
+        for pr_id, title, worker_id in test_data:
+            thread = Thread(target=process_pr_worker, args=(pr_id, title, worker_id))
+            threads.append(thread)
+
+        # Start all threads
+        for thread in threads:
+            thread.start()
+
+        # Wait for all threads to complete
+        for thread in threads:
+            thread.join()
+
+        # Verify no errors occurred
+        self.assertEqual(len(errors), 0, f"Errors occurred: {errors}")
+
+        # Verify each worker got the correct data
+        self.assertEqual(len(results), 4)
+
+        # Check each result
+        self.assertEqual(results['worker1']['pr_id'], 100)
+        self.assertEqual(results['worker1']['title'], "test PR")
+        self.assertIn("Pull Request 100: test PR", results['worker1']['asana_title'])
+
+        self.assertEqual(results['worker2']['pr_id'], 123)
+        self.assertEqual(results['worker2']['title'], "another test pr")
+        self.assertIn("Pull Request 123: another test pr", results['worker2']['asana_title'])
+
+        self.assertEqual(results['worker3']['pr_id'], 456)
+        self.assertEqual(results['worker3']['title'], "third pr title")
+        self.assertIn("Pull Request 456: third pr title", results['worker3']['asana_title'])
+
+        self.assertEqual(results['worker4']['pr_id'], 789)
+        self.assertEqual(results['worker4']['title'], "fourth pr title")
+        self.assertIn("Pull Request 789: fourth pr title", results['worker4']['asana_title'])
+
+        # Verify no cross-contamination occurred
+        for worker_id, result in results.items():
+            for other_worker_id, other_result in results.items():
+                if worker_id != other_worker_id:
+                    # Ensure this worker's data doesn't match other worker's data incorrectly
+                    self.assertNotEqual(
+                        result['pr_id'], other_result['pr_id'],
+                        f"Workers {worker_id} and {other_worker_id} have same PR ID"
+                    )
+
+    def test_corrupted_data_cleanup_on_save(self):
+        """Test that corrupted data is cleaned up when saving valid data."""
+        # Mock app with corrupted data in the database
+        corrupted_records = [
+            {
+                "ado_pr_id": 123,
+                "ado_repository_id": "repo-456",
+                "title": "test PR",
+                "status": "active",
+                "url": "https://dev.azure.com/test/project/_git/repo/pullrequest/100",  # Wrong URL!
+                "reviewer_gid": "reviewer-gid-1",
+                "reviewer_name": "Test Reviewer",
+                "asana_gid": "asana-task-123"
+            }
+        ]
+
+        self.mock_app.pr_matches.search.return_value = corrupted_records
+        self.mock_app.pr_matches.contains.return_value = False  # No existing record for new item
+        self.mock_app.pr_matches.remove = Mock()
+
+        # Create a valid PR item to save
+        valid_pr_item = PullRequestItem(
+            ado_pr_id=123,
+            ado_repository_id="repo-456",
+            title="test PR",
+            status="active",
+            url="https://dev.azure.com/test/project/_git/repo/pullrequest/123",  # Correct URL
+            reviewer_gid="reviewer-gid-2",  # Different reviewer
+            reviewer_name="Another Reviewer"
+        )
+
+        # Save the valid item (should trigger cleanup)
+        valid_pr_item.save(self.mock_app)
+
+        # Verify that the corrupted record was removed
+        self.mock_app.pr_matches.remove.assert_called()
+        self.mock_app.pr_matches.insert.assert_called_once()
+
+    def test_corrupted_data_cleanup_startup(self):
+        """Test the startup cleanup of all corrupted records."""
+        # Mock corrupted records in database
+        corrupted_records = [
+            {
+                "ado_pr_id": 123,
+                "ado_repository_id": "repo-456",
+                "title": "test PR",
+                "status": "active",
+                "url": "https://dev.azure.com/test/project/_git/repo/pullrequest/100",  # Wrong URL
+                "reviewer_gid": "reviewer-gid-1",
+                "reviewer_name": "Test Reviewer",
+                "asana_gid": "asana-task-123"
+            },
+            {
+                "ado_pr_id": 456,
+                "ado_repository_id": "repo-789",
+                "title": "valid PR",
+                "status": "active",
+                "url": "https://dev.azure.com/test/project/_git/repo/pullrequest/456",  # Correct URL
+                "reviewer_gid": "reviewer-gid-2",
+                "reviewer_name": "Valid Reviewer",
+                "asana_gid": "asana-task-456"
+            }
+        ]
+
+        self.mock_app.pr_matches.all.return_value = corrupted_records
+        self.mock_app.pr_matches.remove = Mock()
+
+        # Run startup cleanup
+        cleaned_count = PullRequestItem.cleanup_all_corrupted_records(self.mock_app)
+
+        # Should clean up only the corrupted record
+        self.assertEqual(cleaned_count, 1)
+        self.mock_app.pr_matches.remove.assert_called_once()
+
+    def test_asana_title_property_immutability(self):
+        """Test that asana_title property always reflects current object state."""
+        pr_item = PullRequestItem(
+            ado_pr_id=100,
+            ado_repository_id="repo-123",
+            title="original title",
+            status="active",
+            url="https://dev.azure.com/test/project/_git/repo/pullrequest/100",
+            reviewer_gid="reviewer-gid-1",
+            reviewer_name="Test Reviewer"
+        )
+
+        # Initial state
+        initial_title = pr_item.asana_title
+        self.assertEqual(initial_title, "Pull Request 100: original title (Test Reviewer)")
+
+        # Update the title (simulating what happens in update_existing_pr_reviewer_task)
+        pr_item.title = "updated title"
+
+        # Verify asana_title reflects the change
+        updated_title = pr_item.asana_title
+        self.assertEqual(updated_title, "Pull Request 100: updated title (Test Reviewer)")
+
+        # Verify ID hasn't changed
+        self.assertEqual(pr_item.ado_pr_id, 100)
+
+        # The key insight: the asana_title property should ALWAYS use the current
+        # values of ado_pr_id and title, not some cached version
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
Introduce data consistency validation and cleanup mechanisms for pull request items during application startup. The implementation includes validation checks to ensure that pull request IDs match expected values, preventing title and ID mismatches. Additionally, a cleanup process removes any corrupted pull request records from previous runs, enhancing data integrity and reliability.

Fixes #400


___

### **PR Type**
Bug fix, Tests


___

### **Description**
Prevent PR ID/title mismatch via validation
Clean up corrupted PR records on startup
Reject and remove inconsistent PR items
Add comprehensive tests for mismatch scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  APP["App.connect startup"] --> CLEANSTART["Cleanup corrupted PR records"]
  PRITEMNEW["PullRequestItem.__init__"] --> VALIDATE1["validate_data_consistency()"]
  SAVE["PullRequestItem.save()"] --> CLEANREC["Cleanup conflicting records"]
  SAVE --> ATOMIC["Atomic upsert with db_lock"]
  SEARCH["PullRequestItem.search()"] --> QUERY["_create_search_query()"]
  SEARCH --> VALIDATERES["Validate search result"]
  SYNC["pull_request_sync flows"] --> SKIPBAD["Skip/update guard on ID mismatch"]
  TESTS["Tests: test_pr_id_title_mismatch.py"] --> COVERAGE["Covers validation, search, save, startup cleanup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Startup cleanup hook for corrupted PR data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/app.py

<ul><li>Call <code>_cleanup_corrupted_pr_data()</code> on connect<br> <li> Implement startup cleanup using <br><code>PullRequestItem.cleanup_all_corrupted_records</code><br> <li> Log cleanup results and failures</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/401/files#diff-c51ca1b6008633c922edec7764f3abd21dfa03be9aef0a10769fbe379a7bae39">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pull_request_item.py</strong><dd><code>PR item validation, safe search, and cleanup utilities</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/pull_request_item.py

<ul><li>Add data consistency validation and logging<br> <li> Harden search with query builder and result validation<br> <li> Clean on save: remove corrupted/conflicting records atomically<br> <li> Provide startup-wide cleanup utilities</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/401/files#diff-02dcc67643d59102820accf9477d18945cf9bf483a36acd23ab64171b0b66468">+226/-23</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pull_request_sync.py</strong><dd><code>Sync guards against mismatched PR IDs and titles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/pull_request_sync.py

<ul><li>Skip corrupted PR items during processing<br> <li> Guard updates when PR IDs mismatch on title change<br> <li> Validate items before closed-PR processing</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/401/files#diff-5f5d4505673a2f86c4ee41696d909ae07efd26dd54dc71501f7d1651976764e3">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_pr_id_title_mismatch.py</strong><dd><code>Tests for PR ID/title mismatch and cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_pr_id_title_mismatch.py

<ul><li>Add comprehensive tests reproducing mismatch<br> <li> Test search rejection and save-time cleanup<br> <li> Test startup cleanup and concurrency isolation<br> <li> Verify asana title reflects current state</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/401/files#diff-3b537ae8fd7f85aa8148c91ff6910eec12b00096943843df573a764a4a8b86a3">+493/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

