### PR TITLE
fix(sync): correctly parse ADO due dates as datetime or string

### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -449,6 +449,10 @@ def extract_due_date_from_ado(ado_work_item) -> str | None:
 
         # Handle datetime objects from ADO API
         if isinstance(due_date_value, datetime):
+            # Normalize timezone-aware datetimes to UTC to ensure consistency
+            # This prevents date mismatches when ADO returns non-UTC timezones
+            if due_date_value.tzinfo is not None:
+                due_date_value = due_date_value.astimezone(timezone.utc)
             return due_date_value.strftime("%Y-%m-%d")
 
         # Handle ISO 8601 strings

--- a/ado_asana_sync/sync/utils.py
+++ b/ado_asana_sync/sync/utils.py
@@ -53,7 +53,7 @@ def convert_ado_date_to_asana_format(iso_datetime_string: str) -> str:
         iso_datetime_string: ISO 8601 datetime string from ADO
 
     Returns:
-        str: Date in YYYY-MM-DD format
+        str: Date in YYYY-MM-DD format (normalized to UTC)
 
     Raises:
         ValueError: If the datetime string is invalid
@@ -63,9 +63,17 @@ def convert_ado_date_to_asana_format(iso_datetime_string: str) -> str:
         raise TypeError("Input must be a non-empty string")
 
     try:
+        from datetime import timezone
+
         # Handle Z timezone suffix by replacing with +00:00
         normalized_string = iso_datetime_string.replace("Z", "+00:00")
         dt = datetime.fromisoformat(normalized_string)
+
+        # Normalize timezone-aware datetimes to UTC to ensure consistency
+        # This prevents date mismatches when different timezones are used
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc)
+
         return dt.strftime("%Y-%m-%d")
     except ValueError as e:
         raise ValueError(f"Invalid datetime format: {iso_datetime_string}") from e

--- a/tests/sync/test_due_date_utils.py
+++ b/tests/sync/test_due_date_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 
@@ -8,11 +8,11 @@ class TestDueDateUtilities(unittest.TestCase):
 
     def test_extract_due_date_from_ado_with_datetime_object(self):
         """
-        Unit Test: extract_due_date_from_ado handles datetime objects from ADO API.
+        Unit Test: extract_due_date_from_ado handles naive datetime objects from ADO API.
         """
         from ado_asana_sync.sync.sync import extract_due_date_from_ado
 
-        # Arrange: Mock ADO work item with datetime object (as returned by real ADO API)
+        # Arrange: Mock ADO work item with naive datetime object
         ado_work_item = MagicMock()
         ado_work_item.fields = {"Microsoft.VSTS.Scheduling.DueDate": datetime(2025, 12, 31, 23, 59, 59)}
         ado_work_item.id = 12345
@@ -22,6 +22,77 @@ class TestDueDateUtilities(unittest.TestCase):
 
         # Assert: Should return date portion only in YYYY-MM-DD format
         self.assertEqual(result, "2025-12-31")
+
+    def test_extract_due_date_from_ado_with_timezone_aware_datetime_utc(self):
+        """
+        Unit Test: extract_due_date_from_ado handles timezone-aware datetime in UTC.
+        """
+        from ado_asana_sync.sync.sync import extract_due_date_from_ado
+
+        # Arrange: Mock ADO work item with UTC timezone-aware datetime
+        ado_work_item = MagicMock()
+        ado_work_item.fields = {"Microsoft.VSTS.Scheduling.DueDate": datetime(2025, 12, 31, 23, 59, 59, tzinfo=timezone.utc)}
+        ado_work_item.id = 12345
+
+        # Act: Extract due date
+        result = extract_due_date_from_ado(ado_work_item)
+
+        # Assert: Should return UTC date in YYYY-MM-DD format
+        self.assertEqual(result, "2025-12-31")
+
+    def test_extract_due_date_from_ado_with_timezone_aware_datetime_non_utc(self):
+        """
+        Unit Test: extract_due_date_from_ado normalizes non-UTC timezone-aware datetimes to UTC.
+
+        This test verifies the critical timezone handling bug fix where non-UTC timezones
+        could result in different dates than the ISO string handling path.
+        """
+        from ado_asana_sync.sync.sync import extract_due_date_from_ado
+
+        # Arrange: Mock ADO work item with datetime in UTC+5 timezone
+        # 2025-12-31 02:00:00+05:00 is equivalent to 2025-12-30 21:00:00 UTC
+        # After UTC normalization, should return "2025-12-30" not "2025-12-31"
+        tz_plus_5 = timezone(timedelta(hours=5))
+        ado_work_item = MagicMock()
+        ado_work_item.fields = {"Microsoft.VSTS.Scheduling.DueDate": datetime(2025, 12, 31, 2, 0, 0, tzinfo=tz_plus_5)}
+        ado_work_item.id = 12345
+
+        # Act: Extract due date
+        result = extract_due_date_from_ado(ado_work_item)
+
+        # Assert: Should normalize to UTC and return UTC date "2025-12-30"
+        self.assertEqual(result, "2025-12-30")
+
+    def test_extract_due_date_timezone_consistency(self):
+        """
+        Unit Test: Verify same moment in time produces same date regardless of representation.
+
+        This test ensures datetime objects and ISO strings produce consistent results
+        when representing the same moment in time.
+        """
+        from ado_asana_sync.sync.sync import extract_due_date_from_ado
+
+        # Same moment in time represented in different ways
+        # 2025-12-30 21:00:00 UTC == 2025-12-31 02:00:00+05:00
+        test_cases = [
+            # Datetime object in UTC
+            datetime(2025, 12, 30, 21, 0, 0, tzinfo=timezone.utc),
+            # Datetime object in UTC+5
+            datetime(2025, 12, 31, 2, 0, 0, tzinfo=timezone(timedelta(hours=5))),
+            # ISO string (tested separately but should match)
+            # "2025-12-30T21:00:00Z" would also produce "2025-12-30"
+        ]
+
+        for dt in test_cases:
+            with self.subTest(datetime=dt):
+                ado_work_item = MagicMock()
+                ado_work_item.fields = {"Microsoft.VSTS.Scheduling.DueDate": dt}
+                ado_work_item.id = 12345
+
+                result = extract_due_date_from_ado(ado_work_item)
+
+                # All representations should produce the same UTC date
+                self.assertEqual(result, "2025-12-30")
 
     def test_extract_due_date_from_ado_with_valid_datetime(self):
         """
@@ -164,6 +235,31 @@ class TestDueDateUtilities(unittest.TestCase):
                 result = convert_ado_date_to_asana_format(iso_string)
 
                 # Assert
+                self.assertEqual(result, expected)
+
+    def test_convert_ado_date_to_asana_format_with_timezone_normalization(self):
+        """
+        Unit Test: convert_ado_date_to_asana_format normalizes non-UTC timezones to UTC.
+
+        This test verifies the timezone normalization fix for ISO string inputs.
+        """
+        from ado_asana_sync.sync.utils import convert_ado_date_to_asana_format
+
+        test_cases = [
+            # UTC+5: 2025-12-31 02:00:00+05:00 = 2025-12-30 21:00:00 UTC → "2025-12-30"
+            ("2025-12-31T02:00:00+05:00", "2025-12-30"),
+            # UTC-8: 2025-12-30 16:00:00-08:00 = 2025-12-31 00:00:00 UTC → "2025-12-31"
+            ("2025-12-30T16:00:00-08:00", "2025-12-31"),
+            # UTC+0 (explicit): Should match Z suffix behavior
+            ("2025-12-31T23:59:59+00:00", "2025-12-31"),
+        ]
+
+        for iso_string, expected in test_cases:
+            with self.subTest(iso_string=iso_string):
+                # Act
+                result = convert_ado_date_to_asana_format(iso_string)
+
+                # Assert: Should normalize to UTC date
                 self.assertEqual(result, expected)
 
     def test_convert_ado_date_to_asana_format_with_invalid_input(self):


### PR DESCRIPTION
### **User description**
The extract_due_date_from_ado() function was only processing string values from the ADO DueDate field. However, the ADO API can return due dates as Python datetime objects, causing them to be skipped and return None instead of being properly converted.

This commit:
- Adds datetime object handling to extract_due_date_from_ado()
- Converts datetime objects directly to YYYY-MM-DD format using strftime()
- Preserves existing ISO 8601 string handling
- Adds unit test for datetime object input
- All 238 tests pass
- All quality checks pass

Due dates from ADO will now sync correctly to Asana during initial task creation, regardless of whether the ADO API returns them as strings or datetime objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix due date parsing for datetime objects

- Preserve ISO 8601 string handling

- Add unit tests for datetime and strings

- Minor import reordering for clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ADO WorkItem DueDate (datetime|string)"] -- "extract_due_date_from_ado" --> B["YYYY-MM-DD string"]
  B -- "used in sync logic" --> C["Asana Task Due Date"]
  T1["New unit tests"] -- "validate datetime & string" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Import order cleanup for Azure modules</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/app.py

<ul><li>Reorder Azure imports to top with others.<br> <li> No functional logic changes.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/429/files#diff-c51ca1b6008633c922edec7764f3abd21dfa03be9aef0a10769fbe379a7bae39">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Robust ADO due date extraction with datetime support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<ul><li>Add handling for datetime due dates via strftime.<br> <li> Keep ISO 8601 string conversion path.<br> <li> Adjust imports ordering; add explicit Azure model imports.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/429/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_due_date_utils.py</strong><dd><code>Tests for datetime and string due date parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_due_date_utils.py

<ul><li>Add test for datetime object DueDate handling.<br> <li> Clarify existing test naming and purpose.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/429/files#diff-2fc78e7146c5e5a0ce2c20275c09244104503bf245362435cf97ac7164c43372">+20/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_sync.py</strong><dd><code>Test imports aligned with production code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_sync.py

<ul><li>Import WorkItem directly for tests consistency.<br> <li> Minor import reordering.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/429/files#diff-dac5b229e36d3c4af2b553d8166f028111f08257c36f93dfecb2929b1a2d2cf0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

