### PR TITLE
fix(docker): install build deps for C-extension compilation in builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,13 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
 
+# Install build dependencies for compiling C extensions (cffi, cryptography, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    build-essential \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 


### PR DESCRIPTION
### **User description**
Install gcc, build-essential, and libffi-dev in the builder stage to support compilation of cffi and cryptography packages. These build tools are required by uv sync when installing dependencies with C extensions but are not included in python:3.14-slim base image.

The build dependencies are only added to the builder stage, keeping the final runtime image small through multi-stage build.

Fixes the error: "command 'gcc' failed: No such file or directory" during dependency installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Docker configuration, Enhancement


___

### **Description**
- Install build tools for C extensions

- Add gcc, build-essential, libffi-dev

- Clean apt lists to reduce image size

- Keep changes confined to builder stage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PythonSlim["Base: python:3.14-slim"] -- "apt-get install" --> BuildDeps["gcc, build-essential, libffi-dev"]
  BuildDeps -- "enable compile" --> CExtensions["cffi, cryptography build"]
  CleanApt["Clean apt lists"] -- "reduce size" --> BuilderImage["Slimmer builder stage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Docker configuration</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add C build dependencies to builder stage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Add apt-get install for gcc, build-essential, libffi-dev.<br> <li> Update/clean apt cache to keep layer small.<br> <li> Comment explains purpose for C extension builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/431/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

