### PR TITLE
chore(deps): disable open Dependabot PRs across ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       interval: "weekly"
     exclude-paths:
       - "requirements.txt"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies ⬆️"
       - "python 🐍"
@@ -20,6 +21,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies ⬆️"
       - "github actions 🛠️"
@@ -28,6 +30,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies ⬆️"
       - "docker 🐋"


### PR DESCRIPTION
### **User description**
Configure Dependabot to limit open pull requests to zero for all package ecosystems, streamlining dependency management.


___

### **PR Type**
Other


___

### **Description**
- Disable automatic Dependabot PR openings

- Apply limit to all configured ecosystems

- Preserve existing schedules and labels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["Dependabot configuration"]
  uv["uv updates"]
  gha["GitHub Actions updates"]
  docker["Docker updates"]
  limit["open-pull-requests-limit: 0"]

  cfg -- "applies to" --> uv
  cfg -- "applies to" --> gha
  cfg -- "applies to" --> docker
  uv -- "sets" --> limit
  gha -- "sets" --> limit
  docker -- "sets" --> limit
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Limit Dependabot PRs for all ecosystems</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Add <code>open-pull-requests-limit: 0</code> to <code>uv</code><br> <li> Add <code>open-pull-requests-limit: 0</code> to <code>github-actions</code><br> <li> Add <code>open-pull-requests-limit: 0</code> to <code>docker</code><br> <li> Leave schedules and labels unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/575/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

