### PR TITLE
chore(deps): create separate PRs for skipped major upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,11 @@
   "separateMajorMinor": true,
   "packageRules": [
     {
-      "description": "Limit major upgrades to 1 version at a time",
+      "description": "Create one PR per skipped major version",
       "matchUpdateTypes": [
         "major"
       ],
-      "maxMajorIncrement": 1
+      "separateMultipleMajor": true
     }
   ]
 }


### PR DESCRIPTION
### **User description**
Update the package rule to ensure that a separate pull request is created for each skipped major version upgrade.


___

### **PR Type**
Other


___

### **Description**
- Split skipped major updates into separate PRs

- Rename rule description for clarity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  r1["Renovate major update rule"]
  r2["separateMultipleMajor: true enabled"]
  r3["One PR per skipped major version"]
  r1 -- "replaced increment limit with" --> r2
  r2 -- "results in" --> r3
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>renovate.json</strong><dd><code>Adjust Renovate major upgrade PR behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

renovate.json

<ul><li>Update the package rule description text<br> <li> Replace <code>maxMajorIncrement</code> with <code>separateMultipleMajor</code><br> <li> Configure Renovate to open one PR per skipped major version</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/583/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

