### PR TITLE
fix: enforce HTTPS uv package index

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
     - cron: "20 7 * * 6"
   workflow_dispatch:
 
+env:
+  UV_DEFAULT_INDEX: https://pypi.org/simple
+
 jobs:
   version:
     name: Generate version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 env:
+  UV_DEFAULT_INDEX: https://pypi.org/simple
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ FROM base AS builder
 
 ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    UV_DEFAULT_INDEX=https://pypi.org/simple
 
 # Install build dependencies for compiling C extensions (cffi, cryptography, etc.)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/ado_asana_sync/database/connection.py
+++ b/ado_asana_sync/database/connection.py
@@ -336,11 +336,13 @@ class Database(DatabaseMigrationsMixin, TinyDBMigrationMixin):
 
             projects = []
             for row in cursor:
-                projects.append({
-                    "adoProjectName": row[0],
-                    "adoTeamName": row[1],
-                    "asanaProjectName": row[2],
-                })
+                projects.append(
+                    {
+                        "adoProjectName": row[0],
+                        "adoTeamName": row[1],
+                        "asanaProjectName": row[2],
+                    }
+                )
 
             return projects
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ dev = [
     "mdformat-gfm>=0.3,<1.1",
 ]
 
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+
 [tool.ruff]
 line-length = 127
 

--- a/tests/utils/test_uv_security_config.py
+++ b/tests/utils/test_uv_security_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPI_SIMPLE_INDEX = "https://pypi.org/simple"
+
+
+class TestUvSecurityConfig(unittest.TestCase):
+    def test_pyproject_explicitly_uses_https_default_index(self) -> None:
+        pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+        indexes = pyproject["tool"]["uv"]["index"]
+
+        self.assertIn(
+            {
+                "name": "pypi",
+                "url": PYPI_SIMPLE_INDEX,
+                "default": True,
+            },
+            indexes,
+        )
+
+    def test_dockerfile_sets_https_index_for_uv(self) -> None:
+        dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+        self.assertIn(f"UV_DEFAULT_INDEX={PYPI_SIMPLE_INDEX}", dockerfile)
+
+    def test_ci_workflows_set_https_index_for_uv(self) -> None:
+        workflow_paths = [
+            REPO_ROOT / ".github" / "workflows" / "build.yml",
+            REPO_ROOT / ".github" / "workflows" / "release.yml",
+        ]
+
+        for workflow_path in workflow_paths:
+            with self.subTest(workflow=workflow_path.name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                self.assertIn(f"UV_DEFAULT_INDEX: {PYPI_SIMPLE_INDEX}", workflow)


### PR DESCRIPTION
### **User description**
## Summary
- make the uv package index explicit in project config with an HTTPS PyPI default index
- export `UV_DEFAULT_INDEX=https://pypi.org/simple` in Docker and GitHub Actions uv execution paths
- add regression coverage for the uv security configuration and apply the repo's pending Ruff format fix in `connection.py`

## Why
SonarCloud flagged the repo for uv usage that did not explicitly enforce an HTTPS package index. uv already defaults to HTTPS, but the enforcement was implicit rather than declared in the repository and CI configuration.

## Validation
- `uv run check`
- `uv run test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Enforce HTTPS uv index in config

- Export `UV_DEFAULT_INDEX` in CI and Docker

- Add regression tests for uv security

- Apply Ruff formatting in database connection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pyproject["pyproject sets HTTPS uv index"]
  workflows["CI workflows export UV_DEFAULT_INDEX"]
  docker["Docker builder exports UV_DEFAULT_INDEX"]
  tests["Tests verify uv security settings"]
  pyproject -- "checked by" --> tests
  workflows -- "checked by" --> tests
  docker -- "checked by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>connection.py</strong><dd><code>Reformat project mapping for Ruff compliance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/database/connection.py

<ul><li>Reformat <code>projects.append(...)</code> for Ruff compliance<br> <li> Preserve existing project mapping behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/629/files#diff-9dbf70e976a778d3f32d053ff2d4ad19c4f60a6e30a0cd9146659132897be1b9">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_uv_security_config.py</strong><dd><code>Add regression tests for uv security config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/test_uv_security_config.py

<ul><li>Add tests for explicit <code>pyproject.toml</code> uv index<br> <li> Verify Dockerfile sets <code>UV_DEFAULT_INDEX</code><br> <li> Verify build and release workflows use HTTPS</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/629/files#diff-bf6405a3ff8093e0f2c9ff8dd44c2f82107d7d71099419f55f5d9feefe856c4d">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Github actions</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.yml</strong><dd><code>Set secure uv index in build workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build.yml

<ul><li>Add top-level <code>UV_DEFAULT_INDEX</code> environment variable<br> <li> Force uv to use HTTPS PyPI index</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/629/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Set secure uv index in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Add top-level <code>UV_DEFAULT_INDEX</code> environment variable<br> <li> Ensure release jobs use HTTPS PyPI index</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/629/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Docker</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Configure Docker uv default package index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Extend builder <code>ENV</code> with <code>UV_DEFAULT_INDEX</code><br> <li> Make Docker uv installs use HTTPS index</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/629/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Declare explicit HTTPS uv default index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add explicit <code>[[tool.uv.index]]</code> configuration<br> <li> Set <code>pypi</code> HTTPS URL as default index</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/629/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

