### PR TITLE
feat: add run-once and dry-run modes AAS-10

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ OTEL_TRACES_SAMPLER_ARG=0.05
 CLOSED_STATES=Closed,Removed,Done
 THREAD_COUNT=8
 SLEEP_TIME=300
+RUN_ONCE=false
+DRY_RUN=false
 SYNCED_TAG_NAME=synced
 
 # Telemetry Logging Configuration

--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,6 @@ OTEL_TRACES_SAMPLER_ARG=0.05
 CLOSED_STATES=Closed,Removed,Done
 THREAD_COUNT=8
 SLEEP_TIME=300
-RUN_ONCE=false
-DRY_RUN=false
 SYNCED_TAG_NAME=synced
 
 # Telemetry Logging Configuration

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ cp .env.example .env
 - `CLOSED_STATES`: Comma-separated ADO states considered closed (default: `Closed,Removed,Done`).
 - `THREAD_COUNT`: Number of projects to sync in parallel (default: `8`).
 - `SLEEP_TIME`: Seconds to sleep between sync runs (default: `300`).
+- `RUN_ONCE`: Run a single sync cycle and exit with a normal process status (default: `false`).
+- `DRY_RUN`: Compute and log planned create/update/close actions without writing to Asana or the local sync database (default: `false`).
 - `SYNC_THRESHOLD`: Days to continue syncing closed tasks before unmapping (default: `30`).
 - `SYNCED_TAG_NAME`: Asana tag appended to all synced items (default: `synced`).
 - `LOGLEVEL`: Console log level (default: `INFO`).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ You can run the sync tool either locally using `uv` or via Docker.
    ```bash
    uv run python -m ado_asana_sync.sync
    ```
+1. **Run a single dry-run or one-shot sync with inline variables:**
+   ```bash
+   DRY_RUN=true RUN_ONCE=true uv run python -m ado_asana_sync.sync
+   ```
 
 #### Option B: Running via Docker
 

--- a/ado_asana_sync/sync/__main__.py
+++ b/ado_asana_sync/sync/__main__.py
@@ -27,7 +27,7 @@ logging.basicConfig(level=log_level)
 
 _LOGGER.debug("Configuring app")
 app = App()
-app.connect()
+app.connect(enable_local_db=not app.dry_run)
 
 if app.run_once:
     _LOGGER.info("Running in one-shot mode (RUN_ONCE=true)")

--- a/ado_asana_sync/sync/__main__.py
+++ b/ado_asana_sync/sync/__main__.py
@@ -29,6 +29,11 @@ _LOGGER.debug("Configuring app")
 app = App()
 app.connect()
 
+if app.run_once:
+    _LOGGER.info("Running in one-shot mode (RUN_ONCE=true)")
+if app.dry_run:
+    _LOGGER.info("Running in dry-run mode (DRY_RUN=true); no writes will be made")
+
 
 def cleanup_handler(_signum=None, _frame=None):
     """Handle cleanup on shutdown."""

--- a/ado_asana_sync/sync/app.py
+++ b/ado_asana_sync/sync/app.py
@@ -124,9 +124,9 @@ class App:
 
         _LOGGER.debug("Created new App instance")
 
-    def connect(self) -> None:
+    def connect(self, enable_local_db: bool = True) -> None:
         """
-        Connects to ADO and Asana, and sets up the TinyDB database.
+        Connect to ADO and Asana, optionally setting up the local SQLite database.
         """
         # Connect ADO.
         _LOGGER.debug("Connecting to Azure DevOps")
@@ -163,6 +163,11 @@ class App:
         )
         _LOGGER.info("Azure Monitor configured with %.1f%% trace sampling", self.trace_sampling_percentage * 100)
         attach_filter_to_telemetry_handlers()
+
+        if not enable_local_db:
+            _LOGGER.info("Skipping local database initialization")
+            return
+
         # Setup SQLite database.
         _LOGGER.debug("Opening local database")
         data_dir = os.path.join(os.path.dirname(__package__), "data")

--- a/ado_asana_sync/sync/app.py
+++ b/ado_asana_sync/sync/app.py
@@ -20,6 +20,8 @@ from msrest.authentication import BasicAuthentication
 from ado_asana_sync.database import Database, DatabaseTable
 from ado_asana_sync.utils.logging_tracing import attach_filter_to_telemetry_handlers
 
+from .dry_run import DryRunReport
+
 # _LOGGER is the logging instance for this file.
 _LOGGER = logging.getLogger(__name__)
 # ASANA_PAGE_SIZE contains the default value for the page size to send to the Asana API.
@@ -28,6 +30,10 @@ ASANA_PAGE_SIZE = 100
 ASANA_TAG_NAME = os.environ.get("SYNCED_TAG_NAME", "synced")
 # SLEEP_TIME defines the sleep time between sync tasks in seconds.
 SLEEP_TIME = max(30, int(os.environ.get("SLEEP_TIME", 300)))
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 class App:
@@ -94,6 +100,9 @@ class App:
         self.pr_matches: Optional[DatabaseTable] = None
         self.config: Optional[DatabaseTable] = None
         self.sleep_time = SLEEP_TIME
+        self.run_once = _env_flag("RUN_ONCE")
+        self.dry_run = _env_flag("DRY_RUN")
+        self.dry_run_report = DryRunReport() if self.dry_run else None
         # Trace sampling configuration for Application Insights
         self.trace_sampling_percentage = float(os.environ.get("OTEL_TRACES_SAMPLER_ARG", "0.05"))  # Default 5%
 

--- a/ado_asana_sync/sync/dry_run.py
+++ b/ado_asana_sync/sync/dry_run.py
@@ -1,0 +1,80 @@
+"""Dry-run tracking helpers for sync operations."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class DryRunReport:
+    task_creates: list[dict[str, int | str]] = field(default_factory=list)
+    task_updates: list[dict[str, int | str]] = field(default_factory=list)
+    task_closes: list[dict[str, int | str]] = field(default_factory=list)
+    pr_creates: list[dict[str, int | str]] = field(default_factory=list)
+    pr_updates: list[dict[str, int | str]] = field(default_factory=list)
+    pr_closes: list[dict[str, int | str]] = field(default_factory=list)
+
+    @property
+    def task_create_ids(self) -> list[int]:
+        return [int(item["ado_id"]) for item in self.task_creates]
+
+    @property
+    def task_update_ids(self) -> list[int]:
+        return [int(item["ado_id"]) for item in self.task_updates]
+
+    @property
+    def task_close_ids(self) -> list[int]:
+        return [int(item["ado_id"]) for item in self.task_closes]
+
+    @property
+    def pr_create_ids(self) -> list[int]:
+        return [int(item["ado_pr_id"]) for item in self.pr_creates]
+
+    @property
+    def pr_update_ids(self) -> list[int]:
+        return [int(item["ado_pr_id"]) for item in self.pr_updates]
+
+    @property
+    def pr_close_ids(self) -> list[int]:
+        return [int(item["ado_pr_id"]) for item in self.pr_closes]
+
+    def record_task_create(self, ado_id: int, title: str) -> None:
+        self.task_creates.append({"ado_id": ado_id, "title": title})
+
+    def record_task_update(self, ado_id: int, title: str) -> None:
+        self.task_updates.append({"ado_id": ado_id, "title": title})
+
+    def record_task_close(self, ado_id: int, title: str) -> None:
+        self.task_closes.append({"ado_id": ado_id, "title": title})
+
+    def record_pr_create(self, ado_pr_id: int, title: str) -> None:
+        self.pr_creates.append({"ado_pr_id": ado_pr_id, "title": title})
+
+    def record_pr_update(self, ado_pr_id: int, title: str) -> None:
+        self.pr_updates.append({"ado_pr_id": ado_pr_id, "title": title})
+
+    def record_pr_close(self, ado_pr_id: int, title: str) -> None:
+        self.pr_closes.append({"ado_pr_id": ado_pr_id, "title": title})
+
+    def log_summary(self) -> None:
+        _LOGGER.info(
+            "Dry-run summary: tasks create=%d update=%d close=%d ids=%s/%s/%s",
+            len(self.task_creates),
+            len(self.task_updates),
+            len(self.task_closes),
+            self.task_create_ids,
+            self.task_update_ids,
+            self.task_close_ids,
+        )
+        _LOGGER.info(
+            "Dry-run summary: pull_requests create=%d update=%d close=%d ids=%s/%s/%s",
+            len(self.pr_creates),
+            len(self.pr_updates),
+            len(self.pr_closes),
+            self.pr_create_ids,
+            self.pr_update_ids,
+            self.pr_close_ids,
+        )

--- a/ado_asana_sync/sync/pr_asana_helpers.py
+++ b/ado_asana_sync/sync/pr_asana_helpers.py
@@ -12,6 +12,7 @@ from ado_asana_sync.utils.date import iso8601_utc
 from ado_asana_sync.utils.logging_tracing import setup_logging_and_tracing
 
 from .asana import get_asana_task
+from .dry_run import DryRunReport
 from .pull_request_item import PullRequestItem
 from .sync import find_custom_field_by_name
 from .utils import encode_url_for_asana
@@ -23,6 +24,30 @@ _LOGGER, _TRACER = setup_logging_and_tracing(__name__)
 
 _PR_CLOSED_STATES = {"completed", "abandoned", "draft"}
 _REVIEWER_APPROVED_STATES = {"approved", "approvedWithSuggestions"}
+
+
+def _is_dry_run(app: App) -> bool:
+    return getattr(app, "dry_run", False) is True
+
+
+def _get_dry_run_report(app: App) -> DryRunReport:
+    report = getattr(app, "dry_run_report", None)
+    if report is None:
+        report = DryRunReport()
+        app.dry_run_report = report
+    return report
+
+
+def _record_pr_action(app: App, action: str, pr_item: PullRequestItem) -> None:
+    report = _get_dry_run_report(app)
+    pr_id = int(pr_item.ado_pr_id)
+    title = str(pr_item.title)
+    if action == "create":
+        report.record_pr_create(ado_pr_id=pr_id, title=title)
+    elif action == "update":
+        report.record_pr_update(ado_pr_id=pr_id, title=title)
+    elif action == "close":
+        report.record_pr_close(ado_pr_id=pr_id, title=title)
 
 
 def _get_cached_custom_field(app: App, asana_project, field_name: str):
@@ -74,6 +99,13 @@ def create_asana_pr_task(app: App, asana_project: str, pr_item: PullRequestItem,
         pr_item.review_status or "none",
         pr_item.status or "none",
     )
+
+    if _is_dry_run(app):
+        _record_pr_action(app, "create", pr_item)
+        pr_item.asana_gid = pr_item.asana_gid or f"dry-run-pr-{pr_item.ado_pr_id}"
+        pr_item.processing_state = "closed" if is_completed else "open"
+        _LOGGER.info("Dry-run mode: would create PR task for PR %s", pr_item.ado_pr_id)
+        return
 
     tasks_api_instance = asana.TasksApi(app.asana_client)
 
@@ -129,6 +161,12 @@ def update_asana_pr_task(app: App, pr_item: PullRequestItem, tag: str, asana_pro
         pr_item.status or "none",
     )
 
+    if _is_dry_run(app):
+        action = "close" if is_completed else "update"
+        _record_pr_action(app, action, pr_item)
+        _LOGGER.info("Dry-run mode: would %s PR task for PR %s", action, pr_item.ado_pr_id)
+        return
+
     tasks_api_instance = asana.TasksApi(app.asana_client)
 
     link_custom_field = _get_cached_custom_field(app, asana_project_gid, "Link")
@@ -170,6 +208,9 @@ def update_asana_pr_task(app: App, pr_item: PullRequestItem, tag: str, asana_pro
 
 def add_tag_to_pr_task(app: App, pr_item: PullRequestItem, tag: str) -> None:
     """Adds a tag to a pull request task if it is not already assigned."""
+    if _is_dry_run(app):
+        _LOGGER.info("Dry-run mode: would tag PR task %s with %s", pr_item.asana_title, tag)
+        return
     api_instance = asana.TagsApi(app.asana_client)
     try:
         api_response = api_instance.get_tags_for_task(pr_item.asana_gid, opts={})
@@ -186,6 +227,9 @@ def add_tag_to_pr_task(app: App, pr_item: PullRequestItem, tag: str) -> None:
 
 def add_closure_comment_to_pr_task(app: App, pr_item: PullRequestItem) -> None:
     """Add a comment to a pull request task explaining why it was closed."""
+    if _is_dry_run(app):
+        _LOGGER.info("Dry-run mode: would add closure comment to PR task %s", pr_item.asana_title)
+        return
     if not pr_item.asana_gid:
         return
 

--- a/ado_asana_sync/sync/pr_processor.py
+++ b/ado_asana_sync/sync/pr_processor.py
@@ -319,7 +319,8 @@ def create_new_pr_reviewer_task(
         pr_item.asana_gid = asana_task["gid"]
         pr_item.asana_updated = asana_task.get("modified_at")
         pr_item.updated_date = iso8601_utc(datetime.now())
-        pr_item.save(app)
+        if getattr(app, "dry_run", False) is not True:
+            pr_item.save(app)
         if app.asana_tag_gid is not None:
             update_asana_pr_task(app, pr_item, app.asana_tag_gid, asana_project)
 
@@ -379,7 +380,8 @@ def update_existing_pr_reviewer_task(
     reviewer_name_updated = False
     if not existing_match.reviewer_name:
         existing_match.reviewer_name = asana_matched_user["name"]
-        existing_match.save(app)
+        if getattr(app, "dry_run", False) is not True:
+            existing_match.save(app)
         reviewer_name_updated = True
         _LOGGER.info("Updated reviewer name for PR task: %s", existing_match.asana_title)
 

--- a/ado_asana_sync/sync/pr_processor.py
+++ b/ado_asana_sync/sync/pr_processor.py
@@ -12,6 +12,7 @@ from .app import App
 from .pr_asana_helpers import (
     _REVIEWER_APPROVED_STATES,
     _get_cached_asana_task,
+    _record_pr_action,
     create_asana_pr_task,
     update_asana_pr_task,
 )
@@ -165,6 +166,9 @@ def _close_removed_reviewer_task(app: App, pr_item: PullRequestItem, asana_proje
             )
     else:
         pr_item.processing_state = "closed"
+        if getattr(app, "dry_run", False) is True:
+            _record_pr_action(app, "close", pr_item)
+            return
         pr_item.save(app)
 
 

--- a/ado_asana_sync/sync/pr_sync_core.py
+++ b/ado_asana_sync/sync/pr_sync_core.py
@@ -14,7 +14,7 @@ from ado_asana_sync.utils.date import iso8601_utc
 from ado_asana_sync.utils.logging_tracing import setup_logging_and_tracing
 
 from .app import App
-from .pr_asana_helpers import _PR_CLOSED_STATES, _get_cached_asana_task, update_asana_pr_task
+from .pr_asana_helpers import _PR_CLOSED_STATES, _get_cached_asana_task, _record_pr_action, update_asana_pr_task
 from .pr_processor import create_ado_user_from_reviewer, process_pull_request
 from .pull_request_item import PullRequestItem
 from .sync import (
@@ -112,6 +112,9 @@ def _finalize_closed_pr_task(app: App, pr_item: PullRequestItem, pr: Any, asana_
         if app.asana_tag_gid is not None:
             update_asana_pr_task(app, pr_item, app.asana_tag_gid, asana_project)
     else:
+        if getattr(app, "dry_run", False) is True:
+            _record_pr_action(app, "close", pr_item)
+            return
         pr_item.save(app)
         _LOGGER.debug(
             "Second pass: PR %d task already completed, updated database record with final review_status='%s'",
@@ -132,6 +135,9 @@ def _handle_inaccessible_pr(app: App, pr_item: PullRequestItem, asana_project: s
         update_asana_pr_task(app, pr_item, app.asana_tag_gid, asana_project)
     else:
         pr_item.processing_state = "closed"
+        if getattr(app, "dry_run", False) is True:
+            _record_pr_action(app, "close", pr_item)
+            return
         pr_item.save(app)
     _LOGGER.info("Closed Asana task for inaccessible PR %d", pr_item.ado_pr_id)
 

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -145,6 +145,9 @@ def start_sync(app: App) -> None:
     while True:
         with _TRACER.start_as_current_span("start_sync") as span:
             span.add_event("Start sync run")
+            if _is_dry_run(app):
+                app.dry_run_report = DryRunReport()
+
             # Check if the cache is valid
             now = datetime.now(timezone.utc)
             if CUSTOM_FIELDS_AVAILABLE and now - LAST_CACHE_REFRESH >= CACHE_VALIDITY_DURATION:
@@ -219,16 +222,17 @@ def read_projects(app: App) -> list:
 def create_tag_if_not_existing(app: App, workspace: str, tag: str) -> str | None:
     """Create a tag for a given workspace if it does not already exist."""
     with _TRACER.start_as_current_span("create_tag_if_not_existing"):
-        # Check if the tag_gid is stored in the config table
-        if app.config is None:
+        tag_gid = None
+        if app.config is not None:
+            tag_config_result = app.config.get(doc_id=1)
+            tag_config = (
+                tag_config_result
+                if not isinstance(tag_config_result, list)
+                else (tag_config_result[0] if tag_config_result else None)
+            )
+            tag_gid = tag_config.get("tag_gid") if tag_config else None
+        elif not _is_dry_run(app):
             raise ValueError("app.config is None")
-        tag_config_result = app.config.get(doc_id=1)
-        tag_config = (
-            tag_config_result
-            if not isinstance(tag_config_result, list)
-            else (tag_config_result[0] if tag_config_result else None)
-        )
-        tag_gid = tag_config.get("tag_gid") if tag_config else None
 
         if tag_gid:
             _LOGGER.info("tag_gid found in database for '%s'", tag)
@@ -257,6 +261,8 @@ def create_tag_if_not_existing(app: App, workspace: str, tag: str) -> str | None
         try:
             _LOGGER.info("tag '%s' not found, creating it", tag)
             api_response = api_instance.create_tag_for_workspace(body, workspace, {})
+            if app.config is None:
+                raise ValueError("app.config is None")
             with app.db_lock:
 
                 def new_config_query_func(record):

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -69,6 +69,8 @@ CUSTOM_FIELDS_AVAILABLE = True
 LAST_CACHE_REFRESH: datetime = datetime.now(timezone.utc)
 CACHE_VALIDITY_DURATION = timedelta(hours=24)
 
+_CONFIG_IS_NONE_MSG = "app.config is None"
+
 
 def _parse_sync_threshold(value: str | None) -> int:
     """Parse the sync threshold environment variable into a non-negative integer."""
@@ -219,56 +221,60 @@ def read_projects(app: App) -> list:
         return projects
 
 
+def _get_tag_gid_from_config(app: App) -> str | None:
+    """Retrieve the cached tag GID from app config, or None if config is absent."""
+    if app.config is None:
+        return None
+    tag_config_result = app.config.get(doc_id=1)
+    if isinstance(tag_config_result, list):
+        tag_config = tag_config_result[0] if tag_config_result else None
+    else:
+        tag_config = tag_config_result
+    return tag_config.get("tag_gid") if tag_config else None
+
+
+def _upsert_tag_gid(app: App, tag_gid: str) -> None:
+    """Persist a tag GID into the app config database."""
+    if app.config is None:
+        raise ValueError(_CONFIG_IS_NONE_MSG)
+    with app.db_lock:
+        app.config.upsert({"tag_gid": tag_gid}, lambda r: r.get("doc_id") == 1)
+
+
+def _handle_existing_tag(app: App, existing_tag: dict) -> str:
+    """Return or persist the GID for an existing Asana tag."""
+    if _is_dry_run(app):
+        _LOGGER.info("Dry-run mode: using existing tag %s without updating local config", existing_tag["gid"])
+        return existing_tag["gid"]
+    _upsert_tag_gid(app, existing_tag["gid"])
+    return existing_tag["gid"]
+
+
 def create_tag_if_not_existing(app: App, workspace: str, tag: str) -> str | None:
     """Create a tag for a given workspace if it does not already exist."""
     with _TRACER.start_as_current_span("create_tag_if_not_existing"):
-        tag_gid = None
-        if app.config is not None:
-            tag_config_result = app.config.get(doc_id=1)
-            tag_config = (
-                tag_config_result
-                if not isinstance(tag_config_result, list)
-                else (tag_config_result[0] if tag_config_result else None)
-            )
-            tag_gid = tag_config.get("tag_gid") if tag_config else None
-        elif not _is_dry_run(app):
-            raise ValueError("app.config is None")
+        tag_gid = _get_tag_gid_from_config(app)
+        if app.config is None and not _is_dry_run(app):
+            raise ValueError(_CONFIG_IS_NONE_MSG)
 
         if tag_gid:
             _LOGGER.info("tag_gid found in database for '%s'", tag)
             return tag_gid
 
-        # If tag_gid does not exist in the config, proceed to get or create the tag
         existing_tag = get_tag_by_name(app, workspace, tag)
         if existing_tag is not None:
-            if _is_dry_run(app):
-                _LOGGER.info("Dry-run mode: using existing tag %s without updating local config", existing_tag["gid"])
-                return existing_tag["gid"]
-            if app.config is None:
-                raise ValueError("app.config is None")
-            with app.db_lock:
+            return _handle_existing_tag(app, existing_tag)
 
-                def config_query_func(record):
-                    return record.get("doc_id") == 1
-
-                app.config.upsert({"tag_gid": existing_tag["gid"]}, config_query_func)
-            return existing_tag["gid"]
         if _is_dry_run(app):
             _LOGGER.info("Dry-run mode: tag '%s' would be created in workspace %s", tag, workspace)
             return "dry-run-tag"
+
         api_instance = asana.TagsApi(app.asana_client)
         body = {"data": {"name": tag}}
         try:
             _LOGGER.info("tag '%s' not found, creating it", tag)
             api_response = api_instance.create_tag_for_workspace(body, workspace, {})
-            if app.config is None:
-                raise ValueError("app.config is None")
-            with app.db_lock:
-
-                def new_config_query_func(record):
-                    return record.get("doc_id") == 1
-
-                app.config.upsert({"tag_gid": api_response["gid"]}, new_config_query_func)
+            _upsert_tag_gid(app, api_response["gid"])
             return api_response["gid"]
         except ApiException as exception:
             _LOGGER.error(

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -30,6 +30,7 @@ from .asana_client import (
     get_asana_workspace,
     get_tag_by_name,
 )
+from .dry_run import DryRunReport
 from .matching import matching_user
 from .task_factory import (
     _build_asana_task_body,
@@ -98,6 +99,28 @@ def _parse_sync_threshold(value: str | None) -> int:
 _SYNC_THRESHOLD = _parse_sync_threshold(os.environ.get("SYNC_THRESHOLD"))
 
 
+def _is_dry_run(app: App) -> bool:
+    return getattr(app, "dry_run", False) is True
+
+
+def _get_dry_run_report(app: App) -> DryRunReport:
+    report = getattr(app, "dry_run_report", None)
+    if report is None:
+        report = DryRunReport()
+        app.dry_run_report = report
+    return report
+
+
+def _record_task_action(app: App, action: str, ado_id: int, title: str) -> None:
+    report = _get_dry_run_report(app)
+    if action == "create":
+        report.record_task_create(ado_id=ado_id, title=title)
+    elif action == "update":
+        report.record_task_update(ado_id=ado_id, title=title)
+    elif action == "close":
+        report.record_task_close(ado_id=ado_id, title=title)
+
+
 def start_sync(app: App) -> None:
     """Start the synchronization process between Azure DevOps and Asana.
 
@@ -142,6 +165,13 @@ def start_sync(app: App) -> None:
                     executor.map(sync_project, [app] * len(projects), projects)
                 except Exception as exception:  # pylint: disable=broad-exception-caught
                     _LOGGER.error("Error in sync_project thread: %s", exception)
+
+            if _is_dry_run(app):
+                _get_dry_run_report(app).log_summary()
+
+            if getattr(app, "run_once", False):
+                _LOGGER.info("Run-once mode enabled, exiting after a single sync cycle")
+                break
 
             _LOGGER.info("Sync process complete, sleeping for %s seconds", app.sleep_time)
 
@@ -207,6 +237,9 @@ def create_tag_if_not_existing(app: App, workspace: str, tag: str) -> str | None
         # If tag_gid does not exist in the config, proceed to get or create the tag
         existing_tag = get_tag_by_name(app, workspace, tag)
         if existing_tag is not None:
+            if _is_dry_run(app):
+                _LOGGER.info("Dry-run mode: using existing tag %s without updating local config", existing_tag["gid"])
+                return existing_tag["gid"]
             if app.config is None:
                 raise ValueError("app.config is None")
             with app.db_lock:
@@ -216,6 +249,9 @@ def create_tag_if_not_existing(app: App, workspace: str, tag: str) -> str | None
 
                 app.config.upsert({"tag_gid": existing_tag["gid"]}, config_query_func)
             return existing_tag["gid"]
+        if _is_dry_run(app):
+            _LOGGER.info("Dry-run mode: tag '%s' would be created in workspace %s", tag, workspace)
+            return "dry-run-tag"
         api_instance = asana.TagsApi(app.asana_client)
         body = {"data": {"name": tag}}
         try:
@@ -238,6 +274,9 @@ def create_tag_if_not_existing(app: App, workspace: str, tag: str) -> str | None
 
 def tag_asana_item(app: App, task: TaskItem, tag: str) -> None:
     """Adds a tag to a given item if it is not already assigned."""
+    if _is_dry_run(app):
+        _LOGGER.info("Dry-run mode: would tag task %s with %s", task.asana_title, tag)
+        return None
     api_instance = asana.TasksApi(app.asana_client)
     task_tags = get_asana_task_tags(app, task)
     task_tags_gids = [t["gid"] for t in task_tags]
@@ -529,10 +568,11 @@ def sync_item_and_children(
 
         if existing_match is None:
             _LOGGER.debug("Work item %d: No existing match found, creating new mapping", ado_task.id)
-            create_new_task_mapping(
+            existing_match = create_new_task_mapping(
                 app, ado_task, asana_matched_user, asana_project_tasks, asana_project, parent_gid=parent_asana_gid
             )
-            existing_match = TaskItem.search(app, ado_id=ado_task.id)
+            if existing_match is None or existing_match.asana_gid is None:
+                existing_match = TaskItem.search(app, ado_id=ado_task.id)
         else:
             _LOGGER.debug("Work item %d: Existing match found, updating", ado_task.id)
             update_existing_task(app, ado_task, existing_match, asana_matched_user, asana_project, parent_gid=parent_asana_gid)
@@ -578,16 +618,18 @@ def create_new_task_mapping(app, ado_task, asana_matched_user, asana_project_tas
             app.asana_tag_gid,
             parent_gid=parent_gid,
         )
-    else:
-        _LOGGER.info("%s:dating task", ado_task.fields[ADO_TITLE])
-        existing_match.asana_gid = asana_task["gid"]
-        update_asana_task(
-            app,
-            existing_match,
-            app.asana_tag_gid,
-            asana_project,
-            parent_gid=parent_gid,
-        )
+        return existing_match
+
+    _LOGGER.info("%s:dating task", ado_task.fields[ADO_TITLE])
+    existing_match.asana_gid = asana_task["gid"]
+    update_asana_task(
+        app,
+        existing_match,
+        app.asana_tag_gid,
+        asana_project,
+        parent_gid=parent_gid,
+    )
+    return existing_match
 
 
 def update_existing_task(app, ado_task, existing_match, asana_matched_user, asana_project, parent_gid=None):
@@ -679,6 +721,9 @@ def remove_mapping(app, wi):
         wi["title"],
         _SYNC_THRESHOLD,
     )
+    if _is_dry_run(app):
+        _record_task_action(app, "close", int(wi["ado_id"]), wi["title"])
+        return
     with app.db_lock:
         app.matches.remove(doc_ids=[wi["doc_id"]])
 
@@ -719,6 +764,12 @@ def update_task_if_needed(app, ado_task, existing_match, asana_users, asana_proj
 
 
 def create_asana_task(app: App, asana_project: str, task: TaskItem, tag: str, parent_gid: str | None = None) -> None:
+    if _is_dry_run(app):
+        _record_task_action(app, "create", int(task.ado_id), str(task.title))
+        task.asana_gid = task.asana_gid or f"dry-run-task-{task.ado_id}"
+        _LOGGER.info("Dry-run mode: would create Asana task for ADO item %s", task.ado_id)
+        return
+
     tasks_api_instance = asana.TasksApi(app.asana_client)
     link_custom_field = find_custom_field_by_name(app, asana_project, "Link")
     link_custom_field_id = link_custom_field.get("custom_field", {}).get("gid") if link_custom_field else None
@@ -736,6 +787,12 @@ def create_asana_task(app: App, asana_project: str, task: TaskItem, tag: str, pa
 
 
 def update_asana_task(app: App, task: TaskItem, tag: str, asana_project_gid: str, parent_gid: str | None = None) -> None:
+    if _is_dry_run(app):
+        action = "close" if task.state in _CLOSED_STATES else "update"
+        _record_task_action(app, action, int(task.ado_id), str(task.title))
+        _LOGGER.info("Dry-run mode: would %s Asana task for ADO item %s", action, task.ado_id)
+        return
+
     tasks_api_instance = asana.TasksApi(app.asana_client)
 
     link_custom_field = find_custom_field_by_name(app, asana_project_gid, "Link")
@@ -826,6 +883,9 @@ def cleanup_invalid_work_items(app: App) -> None:
             _LOGGER.info("Removing invalid work item entry with ID: %s", task["ado_id"])
 
     if invalid_items:
+        if _is_dry_run(app):
+            _LOGGER.info("Dry-run mode: would remove %d invalid work item entries", len(invalid_items))
+            return
         with app.db_lock:
             app.matches.remove(doc_ids=invalid_items)
         _LOGGER.info("Cleaned up %d invalid work item entries", len(invalid_items))

--- a/tests/sync/test_app.py
+++ b/tests/sync/test_app.py
@@ -73,6 +73,25 @@ class TestApp(unittest.TestCase):
         app.asana_page_size = 50
         self.assertEqual(app.asana_page_size, 50)
 
+    @patch.dict(
+        os.environ,
+        {
+            "ADO_PAT": "env_pat",
+            "ADO_URL": "https://dev.azure.com/env",
+            "ASANA_TOKEN": "env_token",
+            "ASANA_WORKSPACE_NAME": "env_workspace",
+            "RUN_ONCE": "true",
+            "DRY_RUN": "1",
+        },
+    )
+    def test_app_runtime_modes_created_from_environment(self):
+        """Test runtime flags are parsed from environment variables."""
+        app = App()
+
+        self.assertTrue(app.run_once)
+        self.assertTrue(app.dry_run)
+        self.assertIsNotNone(app.dry_run_report)
+
     def test_app_close_cleans_up_database(self):
         """Test that close() method cleans up resources."""
         app = App(

--- a/tests/sync/test_app_database.py
+++ b/tests/sync/test_app_database.py
@@ -100,6 +100,50 @@ class TestAppDatabase(unittest.TestCase):
             "ADO_URL": "https://dev.azure.com/test",
             "ASANA_TOKEN": "test_token",
             "ASANA_WORKSPACE_NAME": "test_workspace",
+            "DRY_RUN": "true",
+        },
+    )
+    @patch("ado_asana_sync.sync.app.configure_azure_monitor")
+    @patch("ado_asana_sync.sync.app.os.path.dirname")
+    @patch("ado_asana_sync.sync.app.Connection")
+    @patch("ado_asana_sync.sync.app.asana.ApiClient")
+    def test_connect_can_skip_local_database_in_dry_run(
+        self,
+        mock_asana_client,
+        mock_ado_connection,
+        mock_dirname,
+        mock_configure,
+    ):
+        """Test that dry-run startup can skip local database initialization entirely."""
+        mock_dirname.return_value = self.test_dir
+        mock_configure.return_value = None
+        mock_ado_connection.return_value = MagicMock()
+        mock_asana_client.return_value = MagicMock()
+
+        data_dir = os.path.join(self.test_dir, "data")
+        os.makedirs(data_dir, exist_ok=True)
+
+        appdata_path = os.path.join(data_dir, "appdata.json")
+        with open(appdata_path, "w", encoding="utf-8") as f:
+            json.dump({"matches": {"1": {"ado_id": 123}}}, f)
+
+        app = App()
+        app.connect(enable_local_db=False)
+
+        self.assertIsNone(app.db)
+        self.assertIsNone(app.matches)
+        self.assertIsNone(app.pr_matches)
+        self.assertIsNone(app.config)
+        self.assertTrue(os.path.exists(appdata_path))
+        self.assertFalse(os.path.exists(os.path.join(data_dir, "appdata.db")))
+
+    @patch.dict(
+        os.environ,
+        {
+            "ADO_PAT": "test_pat",
+            "ADO_URL": "https://dev.azure.com/test",
+            "ASANA_TOKEN": "test_token",
+            "ASANA_WORKSPACE_NAME": "test_workspace",
         },
     )
     @patch("ado_asana_sync.sync.app.os.path.dirname")

--- a/tests/sync/test_pr_dry_run.py
+++ b/tests/sync/test_pr_dry_run.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ado_asana_sync.sync.dry_run import DryRunReport
+from ado_asana_sync.sync.pull_request_sync import create_asana_pr_task, update_asana_pr_task
+
+
+class TestPullRequestDryRun(unittest.TestCase):
+    @patch("ado_asana_sync.sync.pr_asana_helpers.find_custom_field_by_name", return_value=None)
+    @patch("asana.TasksApi")
+    def test_create_asana_pr_task_dry_run_skips_write(self, mock_tasks_api_class, _mock_custom_field):
+        app = MagicMock()
+        app.dry_run = True
+        app.dry_run_report = DryRunReport()
+        pr_item = MagicMock()
+        pr_item.ado_pr_id = 901
+        pr_item.title = "PR create"
+        pr_item.asana_title = "PR 901: PR create"
+        pr_item.asana_notes_link = "note"
+        pr_item.status = "active"
+        pr_item.review_status = "waitingForAuthor"
+        pr_item.url = "https://example.com/pr/901"
+        pr_item.reviewer_gid = "user-1"
+        pr_item.asana_gid = None
+
+        create_asana_pr_task(app, "project-gid", pr_item, "tag-gid")
+
+        mock_tasks_api_class.return_value.create_task.assert_not_called()
+        pr_item.save.assert_not_called()
+        self.assertEqual(pr_item.asana_gid, "dry-run-pr-901")
+        self.assertEqual(app.dry_run_report.pr_create_ids, [901])
+
+    @patch("ado_asana_sync.sync.pr_asana_helpers.add_closure_comment_to_pr_task")
+    @patch("ado_asana_sync.sync.pr_asana_helpers.add_tag_to_pr_task")
+    @patch("ado_asana_sync.sync.pr_asana_helpers.find_custom_field_by_name", return_value=None)
+    @patch("asana.TasksApi")
+    def test_update_asana_pr_task_dry_run_records_close(
+        self,
+        mock_tasks_api_class,
+        _mock_custom_field,
+        _mock_add_tag,
+        _mock_add_comment,
+    ):
+        app = MagicMock()
+        app.dry_run = True
+        app.dry_run_report = DryRunReport()
+        pr_item = MagicMock()
+        pr_item.ado_pr_id = 902
+        pr_item.title = "PR close"
+        pr_item.asana_gid = "asana-pr-902"
+        pr_item.asana_title = "PR 902: PR close"
+        pr_item.asana_notes_link = "note"
+        pr_item.status = "completed"
+        pr_item.review_status = "approved"
+        pr_item.url = "https://example.com/pr/902"
+        pr_item.reviewer_gid = "user-2"
+
+        update_asana_pr_task(app, pr_item, "tag-gid", "project-gid")
+
+        mock_tasks_api_class.return_value.update_task.assert_not_called()
+        pr_item.save.assert_not_called()
+        self.assertEqual(app.dry_run_report.pr_close_ids, [902])

--- a/tests/sync/test_pr_dry_run.py
+++ b/tests/sync/test_pr_dry_run.py
@@ -1,7 +1,10 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from ado_asana_sync.sync.dry_run import DryRunReport
+from ado_asana_sync.sync.pr_processor import create_new_pr_reviewer_task, update_existing_pr_reviewer_task
+from ado_asana_sync.sync.pull_request_item import PullRequestItem
 from ado_asana_sync.sync.pull_request_sync import create_asana_pr_task, update_asana_pr_task
 
 
@@ -60,3 +63,92 @@ class TestPullRequestDryRun(unittest.TestCase):
         mock_tasks_api_class.return_value.update_task.assert_not_called()
         pr_item.save.assert_not_called()
         self.assertEqual(app.dry_run_report.pr_close_ids, [902])
+
+    @patch("ado_asana_sync.sync.pr_processor.extract_reviewer_vote", return_value="waitingForAuthor")
+    @patch("ado_asana_sync.sync.pr_processor.update_asana_pr_task")
+    @patch("ado_asana_sync.sync.pr_processor.PullRequestItem.save")
+    @patch(
+        "ado_asana_sync.sync.pr_processor.get_asana_task_by_name",
+        return_value={"gid": "asana-pr-903", "modified_at": "2026-05-31T04:00:00Z"},
+    )
+    def test_create_new_pr_reviewer_task_dry_run_skips_local_save_for_existing_task(
+        self,
+        _mock_get_task,
+        mock_save,
+        mock_update_task,
+        _mock_vote,
+    ):
+        app = MagicMock()
+        app.dry_run = True
+        app.ado_url = "https://dev.azure.com/example"
+        app.asana_tag_gid = "tag-gid"
+        pr = SimpleNamespace(
+            pull_request_id=903,
+            title="Existing PR",
+            status="active",
+            web_url="https://example.com/pr/903",
+        )
+        repository = SimpleNamespace(
+            id="repo-1",
+            name="repo",
+            project=SimpleNamespace(name="project"),
+        )
+
+        create_new_pr_reviewer_task(
+            app,
+            pr,
+            repository,
+            reviewer=MagicMock(),
+            asana_matched_user={"gid": "user-3", "name": "Reviewer"},
+            asana_project_tasks=[],
+            asana_project="project-gid",
+        )
+
+        mock_save.assert_not_called()
+        mock_update_task.assert_called_once()
+
+    @patch("ado_asana_sync.sync.pr_processor.extract_reviewer_vote", return_value="waitingForAuthor")
+    @patch("ado_asana_sync.sync.pr_processor.update_asana_pr_task")
+    @patch("ado_asana_sync.sync.pr_processor._get_cached_asana_task", return_value={"modified_at": "2026-05-31T04:00:00Z"})
+    @patch("ado_asana_sync.sync.pr_processor.PullRequestItem.save")
+    def test_update_existing_pr_reviewer_task_dry_run_skips_reviewer_name_save(
+        self,
+        mock_save,
+        _mock_cached_task,
+        mock_update_task,
+        _mock_vote,
+    ):
+        app = MagicMock()
+        app.dry_run = True
+        app.asana_tag_gid = "tag-gid"
+        pr = SimpleNamespace(
+            pull_request_id=904,
+            title="PR needing reviewer backfill",
+            status="active",
+        )
+        existing_match = PullRequestItem(
+            ado_pr_id=904,
+            ado_repository_id="repo-1",
+            title="PR needing reviewer backfill",
+            status="active",
+            url="https://example.com/pr/904",
+            reviewer_gid="user-4",
+            reviewer_name=None,
+            asana_gid="asana-pr-904",
+            asana_updated="2026-05-31T04:00:00Z",
+            review_status="waitingForAuthor",
+        )
+
+        update_existing_pr_reviewer_task(
+            app,
+            pr,
+            _repository=MagicMock(),
+            reviewer=MagicMock(),
+            existing_match=existing_match,
+            asana_matched_user={"gid": "user-4", "name": "Reviewer Four"},
+            asana_project="project-gid",
+        )
+
+        self.assertEqual(existing_match.reviewer_name, "Reviewer Four")
+        mock_save.assert_not_called()
+        mock_update_task.assert_called_once()

--- a/tests/sync/test_runtime_modes.py
+++ b/tests/sync/test_runtime_modes.py
@@ -4,7 +4,13 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from ado_asana_sync.sync.dry_run import DryRunReport
-from ado_asana_sync.sync.sync import create_asana_task, remove_mapping, start_sync, update_asana_task
+from ado_asana_sync.sync.sync import (
+    create_asana_task,
+    create_tag_if_not_existing,
+    remove_mapping,
+    start_sync,
+    update_asana_task,
+)
 
 
 class _ExecutorStub:
@@ -20,6 +26,16 @@ class _ExecutorStub:
 
 
 class TestRuntimeModes(unittest.TestCase):
+    @patch("ado_asana_sync.sync.sync.get_tag_by_name", return_value={"gid": "existing-tag"})
+    def test_create_tag_if_not_existing_dry_run_without_config_uses_existing_tag(self, _mock_get_tag):
+        app = MagicMock()
+        app.config = None
+        app.dry_run = True
+
+        tag_gid = create_tag_if_not_existing(app, "workspace-gid", "synced")
+
+        self.assertEqual(tag_gid, "existing-tag")
+
     @patch("ado_asana_sync.sync.sync.sleep")
     @patch("ado_asana_sync.sync.sync.sync_project")
     @patch("ado_asana_sync.sync.sync.read_projects", return_value=[{"adoProjectName": "A", "adoTeamName": "B"}])
@@ -47,6 +63,45 @@ class TestRuntimeModes(unittest.TestCase):
         mock_read_projects.assert_called_once_with(app)
         mock_sync_project.assert_called_once()
         mock_sleep.assert_not_called()
+
+    @patch("ado_asana_sync.sync.sync.sleep", side_effect=[None, RuntimeError("stop after second cycle")])
+    @patch("ado_asana_sync.sync.sync.read_projects", return_value=[{"adoProjectName": "A", "adoTeamName": "B"}])
+    @patch("ado_asana_sync.sync.sync.create_tag_if_not_existing", return_value="tag-gid")
+    @patch("ado_asana_sync.sync.sync.get_asana_workspace", return_value="workspace-gid")
+    @patch("ado_asana_sync.sync.sync.concurrent.futures.ThreadPoolExecutor", return_value=_ExecutorStub())
+    def test_start_sync_resets_dry_run_report_each_cycle(
+        self,
+        _mock_executor,
+        _mock_workspace,
+        _mock_tag,
+        _mock_read_projects,
+        mock_sleep,
+    ):
+        app = MagicMock()
+        app.asana_workspace_name = "workspace"
+        app.asana_tag_name = "synced"
+        app.run_once = False
+        app.dry_run = True
+        app.dry_run_report = DryRunReport()
+        app.sleep_time = 30
+
+        call_count = 0
+
+        def sync_project_side_effect(sync_app, _project):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                self.assertEqual(sync_app.dry_run_report.task_create_ids, [])
+            sync_app.dry_run_report.record_task_create(call_count, f"Task {call_count}")
+
+        with (
+            patch("ado_asana_sync.sync.sync.sync_project", side_effect=sync_project_side_effect),
+            self.assertRaisesRegex(RuntimeError, "stop after second cycle"),
+        ):
+            start_sync(app)
+
+        self.assertEqual(call_count, 2)
+        self.assertEqual(mock_sleep.call_count, 2)
 
     def test_dry_run_report_logs_summary(self):
         report = DryRunReport()

--- a/tests/sync/test_runtime_modes.py
+++ b/tests/sync/test_runtime_modes.py
@@ -1,0 +1,127 @@
+import unittest
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ado_asana_sync.sync.dry_run import DryRunReport
+from ado_asana_sync.sync.sync import create_asana_task, remove_mapping, start_sync, update_asana_task
+
+
+class _ExecutorStub:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def map(self, func, apps, projects):
+        for app, project in zip(apps, projects, strict=False):
+            func(app, project)
+
+
+class TestRuntimeModes(unittest.TestCase):
+    @patch("ado_asana_sync.sync.sync.sleep")
+    @patch("ado_asana_sync.sync.sync.sync_project")
+    @patch("ado_asana_sync.sync.sync.read_projects", return_value=[{"adoProjectName": "A", "adoTeamName": "B"}])
+    @patch("ado_asana_sync.sync.sync.create_tag_if_not_existing", return_value="tag-gid")
+    @patch("ado_asana_sync.sync.sync.get_asana_workspace", return_value="workspace-gid")
+    @patch("ado_asana_sync.sync.sync.concurrent.futures.ThreadPoolExecutor", return_value=_ExecutorStub())
+    def test_start_sync_run_once_exits_after_single_cycle(
+        self,
+        _mock_executor,
+        _mock_workspace,
+        _mock_tag,
+        mock_read_projects,
+        mock_sync_project,
+        mock_sleep,
+    ):
+        app = MagicMock()
+        app.asana_workspace_name = "workspace"
+        app.asana_tag_name = "synced"
+        app.run_once = True
+        app.dry_run = False
+        app.sleep_time = 30
+
+        start_sync(app)
+
+        mock_read_projects.assert_called_once_with(app)
+        mock_sync_project.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    def test_dry_run_report_logs_summary(self):
+        report = DryRunReport()
+        report.record_task_create(ado_id=101, title="Create task")
+        report.record_task_update(ado_id=102, title="Update task")
+        report.record_task_close(ado_id=103, title="Close task")
+        report.record_pr_create(ado_pr_id=201, title="Create PR task")
+        report.record_pr_update(ado_pr_id=202, title="Update PR task")
+        report.record_pr_close(ado_pr_id=203, title="Close PR task")
+
+        stream = StringIO()
+        with patch("ado_asana_sync.sync.dry_run._LOGGER") as mock_logger:
+            mock_logger.info.side_effect = lambda message, *args: stream.write(message % args if args else message)
+            report.log_summary()
+
+        output = stream.getvalue()
+        self.assertIn("tasks create=1 update=1 close=1", output)
+        self.assertIn("pull_requests create=1 update=1 close=1", output)
+        self.assertIn("101", output)
+        self.assertIn("203", output)
+
+    @patch("ado_asana_sync.sync.sync.find_custom_field_by_name", return_value=None)
+    @patch("asana.TasksApi")
+    def test_create_asana_task_dry_run_skips_asana_write(self, mock_tasks_api_class, _mock_custom_field):
+        app = MagicMock()
+        app.dry_run = True
+        app.dry_run_report = DryRunReport()
+        task = SimpleNamespace(
+            ado_id=321,
+            title="New task",
+            asana_title="Task 321: New task",
+            asana_notes_link="note",
+            assigned_to=None,
+            state="New",
+            due_date=None,
+            url="https://example.com/321",
+            asana_gid=None,
+        )
+
+        create_asana_task(app, "project-gid", task, "tag-gid")
+
+        mock_tasks_api_class.return_value.create_task.assert_not_called()
+        self.assertEqual(task.asana_gid, "dry-run-task-321")
+        self.assertEqual(app.dry_run_report.task_create_ids, [321])
+
+    @patch("ado_asana_sync.sync.sync.find_custom_field_by_name", return_value=None)
+    @patch("ado_asana_sync.sync.sync.tag_asana_item")
+    @patch("asana.TasksApi")
+    def test_update_asana_task_dry_run_skips_asana_write(self, mock_tasks_api_class, _mock_tag, _mock_custom_field):
+        app = MagicMock()
+        app.dry_run = True
+        app.dry_run_report = DryRunReport()
+        task = MagicMock()
+        task.ado_id = 654
+        task.title = "Updated task"
+        task.asana_title = "Task 654: Updated task"
+        task.asana_notes_link = "note"
+        task.assigned_to = None
+        task.state = "Active"
+        task.url = "https://example.com/654"
+        task.asana_gid = "asana-654"
+
+        update_asana_task(app, task, "tag-gid", "project-gid")
+
+        mock_tasks_api_class.return_value.update_task.assert_not_called()
+        task.save.assert_not_called()
+        self.assertEqual(app.dry_run_report.task_update_ids, [654])
+
+    def test_remove_mapping_dry_run_skips_database_write(self):
+        app = MagicMock()
+        app.dry_run = True
+        app.dry_run_report = DryRunReport()
+        wi = {"ado_id": 777, "item_type": "Bug", "title": "Old item", "doc_id": 12}
+
+        remove_mapping(app, wi)
+
+        app.matches.remove.assert_not_called()
+        self.assertEqual(app.dry_run_report.task_close_ids, [777])


### PR DESCRIPTION
## Summary
- add `RUN_ONCE` mode so the sync loop can execute a single cycle and exit cleanly
- add `DRY_RUN` mode so task and PR sync paths report planned create/update/close work without writing to Asana or the local sync database
- document both runtime flags and add coverage for app config, sync loop behavior, and dry-run write suppression

## Why
This enables CI validation, safer rollout testing, and reproducible one-shot sync runs without requiring external process termination or risking live mutations.

## Validation
- `uv run check`
- `uv run test`
