### PR TITLE
fix: resolve ResourceWarning unclosed sqlite3 connections in tests AAS-50

### DIFF
--- a/ado_asana_sync/database/connection.py
+++ b/ado_asana_sync/database/connection.py
@@ -355,6 +355,9 @@ class Database(DatabaseMigrationsMixin, TinyDBMigrationMixin):
         for conn in connections_to_close:
             try:
                 conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                _LOGGER.warning("Error checkpointing database connection: %s", exc)
+            try:
                 conn.close()
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 _LOGGER.warning("Error closing database connection: %s", exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ ignore = [
 [tool.ruff.lint.mccabe]
 max-complexity = 10
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error::ResourceWarning",
+]
+
 [tool.coverage.run]
 relative_files = true
 omit = ["tests/*"]

--- a/tests/sync/test_group_reviewer.py
+++ b/tests/sync/test_group_reviewer.py
@@ -113,18 +113,27 @@ class TestGroupReviewerConfig(unittest.TestCase):
         env.pop("GROUP_REVIEWER_STRATEGY", None)
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app(tmp)
-        self.assertEqual(app.group_reviewer_strategy, "ignore")
+            try:
+                self.assertEqual(app.group_reviewer_strategy, "ignore")
+            finally:
+                app.db.close()
 
     def test_valid_strategy_unassigned_task(self):
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app(tmp, strategy="unassigned_task")
-        self.assertEqual(app.group_reviewer_strategy, "unassigned_task")
+            try:
+                self.assertEqual(app.group_reviewer_strategy, "unassigned_task")
+            finally:
+                app.db.close()
 
     def test_valid_strategy_default_user_with_user_set(self):
         with tempfile.TemporaryDirectory() as tmp:
             app = _make_app(tmp, strategy="default_user", default_user="fallback@example.com")
-        self.assertEqual(app.group_reviewer_strategy, "default_user")
-        self.assertEqual(app.group_reviewer_default_user, "fallback@example.com")
+            try:
+                self.assertEqual(app.group_reviewer_strategy, "default_user")
+                self.assertEqual(app.group_reviewer_default_user, "fallback@example.com")
+            finally:
+                app.db.close()
 
     def test_invalid_strategy_falls_back_to_ignore(self):
         with patch.dict(os.environ, {"GROUP_REVIEWER_STRATEGY": "nonsense"}, clear=False):
@@ -217,7 +226,9 @@ class TestHandleGroupReviewer(unittest.TestCase):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     def _app(self, strategy="ignore", default_user=""):
-        return _make_app(self.tmp, strategy=strategy, default_user=default_user)
+        app = _make_app(self.tmp, strategy=strategy, default_user=default_user)
+        self.addCleanup(app.db.close)
+        return app
 
     def test_ignore_strategy_creates_no_task(self):
         app = self._app(strategy="ignore")
@@ -399,7 +410,9 @@ class TestCurrentReviewerGidsDefaultUserFallback(unittest.TestCase):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     def _app(self, strategy="ignore", default_user=""):
-        return _make_app(self.tmp, strategy=strategy, default_user=default_user)
+        app = _make_app(self.tmp, strategy=strategy, default_user=default_user)
+        self.addCleanup(app.db.close)
+        return app
 
     @patch("ado_asana_sync.sync.pr_processor.handle_removed_reviewers")
     @patch("ado_asana_sync.sync.pr_processor._handle_group_reviewer")


### PR DESCRIPTION
## Summary

- Fixes `ResourceWarning: unclosed database` warnings in `tests/sync/test_group_reviewer.py` by ensuring every `Database` instance created via `_make_app()` is explicitly closed
- Adds defensive fix in `Database.close()` so `conn.close()` is always called even when the WAL checkpoint PRAGMA raises an exception
- Adds `filterwarnings = ["error::ResourceWarning"]` to pytest config to turn future unclosed connections into test failures immediately

## Test plan

- [x] `uv run python -W error::ResourceWarning -m pytest tests/sync/test_group_reviewer.py -v` — 31 passed, 0 warnings
- [x] `uv run test` — 359 passed, 0 warnings
- [x] `uv run lint && uv run format-check` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)