### PR TITLE
docs: update documentation with missing env vars, modules, and persistence details (AAS-52)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ OTEL_TRACES_SAMPLER_ARG=0.05
 CLOSED_STATES=Closed,Removed,Done
 THREAD_COUNT=8
 SLEEP_TIME=300
+RUN_ONCE=false
+DRY_RUN=false
 SYNCED_TAG_NAME=synced
 
 # Group/container reviewer fallback strategy (ignore | default_user | unassigned_task, default: ignore)

--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ OTEL_TRACES_SAMPLER_ARG=0.05
 CLOSED_STATES=Closed,Removed,Done
 THREAD_COUNT=8
 SLEEP_TIME=300
-RUN_ONCE=false
-DRY_RUN=false
+# RUN_ONCE=false
+# DRY_RUN=false
 SYNCED_TAG_NAME=synced
 
 # Group/container reviewer fallback strategy (ignore | default_user | unassigned_task, default: ignore)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,19 @@ Follow these steps to set up your development environment:
 
 - `ado_asana_sync/sync/app.py`: Serves as the main application entry point.
 - `ado_asana_sync/sync/sync.py`: Contains the core synchronization logic between ADO and Asana.
-- `ado_asana_sync/sync/asana.py`: Manages all interactions with the Asana API.
+- `ado_asana_sync/sync/asana.py`: Manages all interactions with the Asana API (tags, task lookups).
+- `ado_asana_sync/sync/asana_client.py`: Asana API helpers for workspaces, projects, tasks, and user membership queries.
+- `ado_asana_sync/sync/ado_parser.py`: ADO-specific item parsing utilities (extracts assigned user details from work items).
+- `ado_asana_sync/sync/matching.py`: User and task matching logic between ADO and Asana (email/display-name lookup).
+- `ado_asana_sync/sync/dry_run.py`: Dry-run tracking helpers; records planned create/update/close actions without writing to Asana.
 - `ado_asana_sync/sync/task_item.py`: Defines the `TaskItem` data structure for task representation.
+- `ado_asana_sync/sync/task_factory.py`: Logic for building Asana task request bodies and saving newly created tasks.
 - `ado_asana_sync/sync/pull_request_item.py`: Defines the `PullRequestItem` data structure for PR-reviewer relationships.
 - `ado_asana_sync/sync/pr_sync_core.py`: PR sync orchestration (`sync_pull_requests`, `process_repository_pull_requests`, `process_closed_pull_requests`).
 - `ado_asana_sync/sync/pr_processor.py`: Logic for processing individual PRs and reviewers (`process_pull_request`, `handle_removed_reviewers`, `process_pr_reviewer`).
 - `ado_asana_sync/sync/pr_asana_helpers.py`: Asana helpers specific to PRs (`create_asana_pr_task`, `update_asana_pr_task`, `add_tag_to_pr_task`, `add_closure_comment_to_pr_task`).
 - `ado_asana_sync/sync/pull_request_sync.py`: Re-export facade for backward compatibility.
+- `ado_asana_sync/sync/utils.py`: Shared utility functions (reviewer vote extraction, date conversion, URL encoding).
 - `data/projects.json.example`: Provides an example of the project data structure required for configuration.
 
 ### Coding Conventions
@@ -104,12 +110,18 @@ uv run pytest tests/e2e/ -v
 - Source: `ado_asana_sync/`
   - `sync/app.py`: entry point
   - `sync/sync.py`: ADO ↔ Asana sync core
-  - `sync/asana.py`: Asana API helpers
+  - `sync/asana.py`: Asana API helpers (tags, task lookups)
+  - `sync/asana_client.py`: workspace/project/task/membership queries
+  - `sync/ado_parser.py`: ADO work item parsing (assigned user extraction)
+  - `sync/matching.py`: ADO ↔ Asana user matching by email/display name
+  - `sync/dry_run.py`: dry-run report tracking (no writes to Asana)
   - `sync/task_item.py`, `sync/pull_request_item.py`: data models
+  - `sync/task_factory.py`: Asana task body construction and save helpers
   - `sync/pr_sync_core.py`: PR sync orchestration
   - `sync/pr_processor.py`: individual PR and reviewer processing
   - `sync/pr_asana_helpers.py`: Asana helpers specific to PRs
   - `sync/pull_request_sync.py`: re-export facade for backward compatibility
+  - `sync/utils.py`: shared utilities (vote extraction, date conversion, URL encoding)
   - `utils/`: logging/tracing, time helpers
   - `database/`: SQLite persistence
 - Config example: `data/projects.json.example`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,19 @@ This repository provides a robust tool for synchronizing tasks between Azure Dev
 - Key files:
   - `ado_asana_sync/sync/app.py`: Main entry point.
   - `ado_asana_sync/sync/sync.py`: Core sync logic including due date synchronization.
-  - `ado_asana_sync/sync/asana.py`: Handles Asana API.
+  - `ado_asana_sync/sync/asana.py`: Handles Asana API (tags, task lookups).
+  - `ado_asana_sync/sync/asana_client.py`: Asana API helpers for workspaces, projects, tasks, and user membership queries.
+  - `ado_asana_sync/sync/ado_parser.py`: ADO-specific item parsing utilities (extracts assigned user details from work items).
+  - `ado_asana_sync/sync/matching.py`: User and task matching logic between ADO and Asana (email/display-name lookup).
+  - `ado_asana_sync/sync/dry_run.py`: Dry-run tracking helpers; records planned create/update/close actions without writing to Asana.
   - `ado_asana_sync/sync/task_item.py`: Task data structure with due_date field support.
+  - `ado_asana_sync/sync/task_factory.py`: Logic for building Asana task request bodies and saving newly created tasks.
   - `ado_asana_sync/sync/pull_request_item.py`: Pull request data structure.
   - `ado_asana_sync/sync/pr_sync_core.py`: PR sync orchestration (top-level sync functions).
   - `ado_asana_sync/sync/pr_processor.py`: Logic for processing individual PRs and reviewers.
   - `ado_asana_sync/sync/pr_asana_helpers.py`: Asana API helpers specific to PRs.
   - `ado_asana_sync/sync/pull_request_sync.py`: Re-export facade for backward compatibility.
+  - `ado_asana_sync/sync/utils.py`: Shared utility functions (reviewer vote extraction, date conversion, URL encoding).
   - `data/projects.json.example`: Example project configuration.
 - Write all code in Python.
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).

--- a/README.md
+++ b/README.md
@@ -86,13 +86,7 @@ cp data/projects.json.example data/projects.json
 
 The application stores its sync state in a SQLite database at `data/appdata.db`. This file tracks which ADO items have been synced to Asana so that subsequent runs perform incremental updates rather than recreating everything from scratch.
 
-**Important for Docker users:** Mount the `data/` directory as a volume to persist the database across container restarts. Without this, the sync database is lost on every restart and all Asana tasks will be recreated.
-
-```yaml
-# compose.yml — ensure the data directory is mounted
-volumes:
-  - ./data:/app/data
-```
+**Important:** Ensure the `data/` directory is persisted across restarts (e.g. via a Docker volume or bind mount). Without this, the sync database is lost and all Asana tasks will be recreated on the next run.
 
 ### Running the Application
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ cp .env.example .env
 - `LOGLEVEL`: Console log level (default: `INFO`).
 - `GROUP_REVIEWER_STRATEGY`: How to handle ADO group/container reviewers (e.g. `[Project]\Contributor`). Options: `ignore` (default, skips them), `default_user` (assigns tasks to `GROUP_REVIEWER_DEFAULT_USER`), `unassigned_task` (creates an unassigned task with the group name).
 - `GROUP_REVIEWER_DEFAULT_USER`: Asana user email, GID, or display name to assign group reviewer tasks to when `GROUP_REVIEWER_STRATEGY=default_user`.
-- *See `.env.example` for additional Application Insights telemetry configurations.*
+- `OTEL_TRACES_SAMPLER_ARG`: Trace sampling percentage for Application Insights (e.g. `0.05` = 5%, `1.0` = 100%; default: `0.05`).
+- `APPINSIGHTS_LOGLEVEL`: Minimum log level forwarded to Application Insights telemetry (default: `WARNING`).
+- `APPINSIGHTS_SAMPLE_DEBUG` / `APPINSIGHTS_SAMPLE_INFO`: Sampling rate for DEBUG/INFO logs sent to Application Insights (default: `0.05`).
+- `APPINSIGHTS_SAMPLE_WARNING` / `APPINSIGHTS_SAMPLE_ERROR` / `APPINSIGHTS_SAMPLE_CRITICAL`: Sampling rate for WARNING/ERROR/CRITICAL logs (default: `1.0`). These default to 100% to preserve incident visibility.
 
 #### 2. Project Mapping
 
@@ -78,6 +81,18 @@ cp data/projects.json.example data/projects.json
 - `adoProjectName`: The name of your Azure DevOps project.
 - `adoTeamName`: The specific team within the ADO project whose backlog you want to sync.
 - `asanaProjectName`: The corresponding Asana project name.
+
+#### 3. Persistence (Data Directory)
+
+The application stores its sync state in a SQLite database at `data/appdata.db`. This file tracks which ADO items have been synced to Asana so that subsequent runs perform incremental updates rather than recreating everything from scratch.
+
+**Important for Docker users:** Mount the `data/` directory as a volume to persist the database across container restarts. Without this, the sync database is lost on every restart and all Asana tasks will be recreated.
+
+```yaml
+# compose.yml — ensure the data directory is mounted
+volumes:
+  - ./data:/app/data
+```
 
 ### Running the Application
 


### PR DESCRIPTION
## Summary

- **README.md**: Expanded optional variables with explicit docs for `OTEL_TRACES_SAMPLER_ARG`, `APPINSIGHTS_LOGLEVEL`, and `APPINSIGHTS_SAMPLE_*`; added a new **Persistence** section explaining the SQLite database and the need to mount `data/` as a Docker volume
- **.env.example**: Added missing `RUN_ONCE=false` and `DRY_RUN=false` entries (both were documented in README but absent from the example file)
- **AGENTS.md**: Added `asana_client.py`, `ado_parser.py`, `matching.py`, `dry_run.py`, `task_factory.py`, and `utils.py` to the Main Components and Project Structure sections
- **CLAUDE.md**: Same module additions to the Key files section

Closes [AAS-52](mention://issue/8d9efea0-1efb-44ec-9c24-955ea33fc3de) — documentation updates identified in audit [AAS-51](mention://issue/d5791c35-be5b-40c4-a33b-7046fd578d5d).

## Test plan

- [x] `uv run check` — all quality checks pass (ruff lint, format, mypy)
- [x] `uv run mdformat --check *.md` — markdown formatting clean
- [x] No code changes; documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)