### PR TITLE
fix: add defensive checks to user matching logic AAS-42

### DIFF
--- a/ado_asana_sync/sync/matching.py
+++ b/ado_asana_sync/sync/matching.py
@@ -10,6 +10,10 @@ def matching_user(user_list: list[dict], ado_user: ADOAssignedUser | None) -> di
     if ado_user is None:
         return None
     for user in user_list:
-        if user["email"].lower() == ado_user.email.lower() or user["name"].lower() == ado_user.display_name.lower():
+        email = user.get("email")
+        name = user.get("name")
+        if isinstance(email, str) and email.lower() == ado_user.email.lower():
+            return user
+        if isinstance(name, str) and name.lower() == ado_user.display_name.lower():
             return user
     return None

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -250,6 +250,51 @@ class TestMatchingUser(unittest.TestCase):
 
         self.assertIsNone(result)
 
+    # Tests that matching_user skips users with a missing email key.
+    def test_matching_user_email_key_missing(self):
+        user_list = [{"name": "User 1"}]
+        ado_user = ADOAssignedUser(display_name="User 9", email="user9@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user skips users with a missing name key.
+    def test_matching_user_name_key_missing(self):
+        user_list = [{"email": "user1@example.com"}]
+        ado_user = ADOAssignedUser(display_name="User 9", email="user9@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user skips users with a None email value.
+    def test_matching_user_email_is_none(self):
+        user_list = [{"email": None, "name": "User 1"}]
+        ado_user = ADOAssignedUser(display_name="User 9", email="user9@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user skips users with a None name value.
+    def test_matching_user_name_is_none(self):
+        user_list = [{"email": "user1@example.com", "name": None}]
+        ado_user = ADOAssignedUser(display_name="User 1", email="user9@example.com")
+
+        result = matching_user(user_list, ado_user)
+
+        self.assertIsNone(result)
+
+    # Tests that matching_user still matches by name when email is missing.
+    def test_matching_user_name_matches_despite_missing_email_key(self):
+        user = {"name": "User 1"}
+        ado_user = ADOAssignedUser(display_name="User 1", email="user9@example.com")
+
+        result = matching_user([user], ado_user)
+
+        self.assertEqual(result, user)
+
 
 class TestSyncItemAndChildrenLogging(unittest.TestCase):
     def test_log_when_user_not_matched(self):


### PR DESCRIPTION
## Summary
- guard `matching_user` against missing or non-string Asana `email` and `name` values
- preserve name-based matching when a profile is missing `email`
- add regression tests for missing keys and `None` values in Asana user profiles

## Root Cause
`matching_user` accessed `user["email"]` and `user["name"]` directly and called `.lower()` on both values. Incomplete Asana user payloads could therefore raise `KeyError` or `AttributeError` during sync.

## Validation
- `uv run pytest tests/sync/test_sync.py::TestMatchingUser -v`
- `uv run lint`
- `uv run type-check`
- `uv run test`
