### PR TITLE
chore: improve renovate github action digest readability

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigestsToSemver",
+    "helpers:githubDigestChangelogs"
   ],
   "separateMajorMinor": true,
   "separateMultipleMajor": true


### PR DESCRIPTION
## Summary

- replace plain GitHub Actions digest pinning with Renovate's semver-aware digest helper
- add GitHub digest changelog compare links for easier review of SHA updates

## Why

This should make GitHub Actions digest updates easier to understand at a glance while retaining digest pinning security.