### PR TITLE
perf: replace full table scans with SQL-based JSON field filtering (AAS-62)

### DIFF
--- a/ado_asana_sync/database/connection.py
+++ b/ado_asana_sync/database/connection.py
@@ -179,6 +179,11 @@ class DatabaseTable:
         where_clause, params = self._build_json_where_clause(conditions)
 
         with self.db.get_connection() as conn:
+            # BEGIN IMMEDIATE acquires a reserved lock before the SELECT so that
+            # no other connection can insert between our SELECT and INSERT,
+            # preventing a TOCTOU duplicate-row race in WAL mode.
+            if not conn.in_transaction:
+                conn.execute("BEGIN IMMEDIATE")
             cursor = conn.execute(
                 f"SELECT id FROM {self.table_name} WHERE {where_clause} LIMIT 1",  # nosec B608 - table_name is controlled, clause is parameterized
                 params,

--- a/ado_asana_sync/database/connection.py
+++ b/ado_asana_sync/database/connection.py
@@ -5,7 +5,7 @@ import logging
 import sqlite3
 import threading
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from .migrations import DatabaseMigrationsMixin
 from .tinydb_migration import TinyDBMigrationMixin
@@ -90,6 +90,114 @@ class DatabaseTable:
     def contains(self, query_func) -> bool:
         """Check if any record matches the query function."""
         return len(self.search(query_func)) > 0
+
+    def _build_json_where_clause(
+        self,
+        conditions: Dict[str, Any],
+        exclude_conditions: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[str, List[Any]]:
+        """Build a parameterized WHERE clause for JSON field filtering."""
+        where_parts: List[str] = []
+        params: List[Any] = []
+
+        for field, value in conditions.items():
+            where_parts.append("json_extract(data, ?) = ?")
+            params.extend([f"$.{field}", value])
+
+        for field, value in (exclude_conditions or {}).items():
+            # NULL-safe: include rows where the field is absent or differs from the excluded value
+            where_parts.append("(json_extract(data, ?) IS NULL OR json_extract(data, ?) != ?)")
+            params.extend([f"$.{field}", f"$.{field}", value])
+
+        where_clause = " AND ".join(where_parts) if where_parts else "1=1"
+        return where_clause, params
+
+    def search_by_json_fields(
+        self,
+        conditions: Dict[str, Any],
+        exclude_conditions: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Search records using SQL JSON field filtering, leveraging database indexes."""
+        where_clause, params = self._build_json_where_clause(conditions, exclude_conditions)
+
+        with self.db.get_connection() as conn:
+            cursor = conn.execute(
+                f"SELECT id, data FROM {self.table_name} WHERE {where_clause}",  # nosec B608 - table_name is controlled, clause is parameterized
+                params,
+            )
+            results = []
+            for row_id, json_data in cursor:
+                record = json.loads(json_data)
+                record["doc_id"] = row_id
+                results.append(record)
+            return results
+
+    def update_by_json_fields(self, data: Dict[str, Any], conditions: Dict[str, Any]) -> List[int]:
+        """Update records matching SQL JSON field conditions."""
+        where_clause, params = self._build_json_where_clause(conditions)
+
+        with self.db.get_connection() as conn:
+            id_cursor = conn.execute(
+                f"SELECT id FROM {self.table_name} WHERE {where_clause}",  # nosec B608 - table_name is controlled, clause is parameterized
+                params,
+            )
+            matching_ids = [row[0] for row in id_cursor]
+
+            if matching_ids:
+                json_data = json.dumps(data, default=str)
+                placeholders = ",".join(["?" for _ in matching_ids])
+                conn.execute(
+                    f"UPDATE {self.table_name} SET data = ?, updated_at = CURRENT_TIMESTAMP "  # nosec B608
+                    f"WHERE id IN ({placeholders})",
+                    [json_data] + matching_ids,
+                )
+
+            return matching_ids
+
+    def remove_by_json_fields(self, conditions: Dict[str, Any]) -> List[int]:
+        """Remove records matching SQL JSON field conditions."""
+        where_clause, params = self._build_json_where_clause(conditions)
+
+        with self.db.get_connection() as conn:
+            id_cursor = conn.execute(
+                f"SELECT id FROM {self.table_name} WHERE {where_clause}",  # nosec B608 - table_name is controlled, clause is parameterized
+                params,
+            )
+            matching_ids = [row[0] for row in id_cursor]
+
+            if matching_ids:
+                placeholders = ",".join(["?" for _ in matching_ids])
+                conn.execute(
+                    f"DELETE FROM {self.table_name} WHERE id IN ({placeholders})",  # nosec B608
+                    matching_ids,
+                )
+
+            return matching_ids
+
+    def upsert_by_json_fields(self, data: Dict[str, Any], conditions: Dict[str, Any]) -> int:
+        """Insert or update a record based on SQL JSON field conditions."""
+        where_clause, params = self._build_json_where_clause(conditions)
+
+        with self.db.get_connection() as conn:
+            cursor = conn.execute(
+                f"SELECT id FROM {self.table_name} WHERE {where_clause} LIMIT 1",  # nosec B608 - table_name is controlled, clause is parameterized
+                params,
+            )
+            row = cursor.fetchone()
+
+            json_data = json.dumps(data, default=str)
+            if row:
+                conn.execute(
+                    f"UPDATE {self.table_name} SET data = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",  # nosec B608
+                    (json_data, row[0]),
+                )
+                return row[0]
+
+            new_cursor = conn.execute(
+                f"INSERT INTO {self.table_name} (data) VALUES (?)",  # nosec B608
+                (json_data,),
+            )
+            return new_cursor.lastrowid
 
     def get(self, doc_id: Optional[int] = None, **kwargs) -> Optional[Dict[str, Any]]:
         """Get a record by doc_id or other criteria."""
@@ -227,13 +335,23 @@ class Database(DatabaseMigrationsMixin, TinyDBMigrationMixin):
             """)
 
             conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_matches_data
+                CREATE INDEX IF NOT EXISTS idx_matches_ado_id
                 ON matches(json_extract(data, '$.ado_id'))
             """)
 
             conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_pr_matches_data
-                ON pr_matches(json_extract(data, '$.pr_id'))
+                CREATE INDEX IF NOT EXISTS idx_matches_asana_gid
+                ON matches(json_extract(data, '$.asana_gid'))
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_pr_matches_ado_pr_id
+                ON pr_matches(json_extract(data, '$.ado_pr_id'))
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_pr_matches_reviewer_gid
+                ON pr_matches(json_extract(data, '$.reviewer_gid'))
             """)
 
     @contextmanager

--- a/ado_asana_sync/database/migrations.py
+++ b/ado_asana_sync/database/migrations.py
@@ -7,7 +7,7 @@ from typing import Protocol
 
 _LOGGER = logging.getLogger(__name__)
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
 
 
 class _ConnectionProvider(Protocol):
@@ -75,6 +75,10 @@ class DatabaseMigrationsMixin:
             self._migrate_to_version_2(conn)
             self._record_migration(conn, 2, "Add composite unique constraint for projects table")
 
+        if current_version < 3:
+            self._migrate_to_version_3(conn)
+            self._record_migration(conn, 3, "Fix pr_matches index and add asana_gid, reviewer_gid indexes")
+
     def get_current_schema_version(self: _ConnectionProvider) -> int:
         """Get the current schema version from the database."""
         with self.get_connection() as conn:
@@ -125,3 +129,18 @@ class DatabaseMigrationsMixin:
             _LOGGER.info("Successfully migrated %d project records", len(existing_projects))
         else:
             _LOGGER.debug("Projects table already has composite unique constraint, skipping migration")
+
+    def _migrate_to_version_3(self, conn):
+        """Migrate to version 3: fix incorrect pr_matches index and add covering indexes."""
+        # Drop the old incorrect index (was on $.pr_id which never existed in the data)
+        conn.execute("DROP INDEX IF EXISTS idx_pr_matches_data")
+        # Rename old matches index to the new consistent naming scheme
+        conn.execute("DROP INDEX IF EXISTS idx_matches_data")
+
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_matches_ado_id ON matches(json_extract(data, '$.ado_id'))")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_matches_asana_gid ON matches(json_extract(data, '$.asana_gid'))")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_pr_matches_ado_pr_id ON pr_matches(json_extract(data, '$.ado_pr_id'))")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pr_matches_reviewer_gid ON pr_matches(json_extract(data, '$.reviewer_gid'))"
+        )
+        _LOGGER.info("Migrated to version 3: updated indexes on matches and pr_matches tables")

--- a/ado_asana_sync/sync/pr_processor.py
+++ b/ado_asana_sync/sync/pr_processor.py
@@ -391,10 +391,7 @@ def handle_removed_reviewers(app: App, pr, current_reviewer_gids: set, asana_pro
     if app.pr_matches is None:
         raise ValueError("app.pr_matches is None")
 
-    def query_func(record):
-        return record.get("ado_pr_id") == pr.pull_request_id
-
-    existing_pr_tasks = app.pr_matches.search(query_func)
+    existing_pr_tasks = app.pr_matches.search_by_json_fields({"ado_pr_id": pr.pull_request_id})
 
     if not existing_pr_tasks:
         return

--- a/ado_asana_sync/sync/pr_sync_core.py
+++ b/ado_asana_sync/sync/pr_sync_core.py
@@ -41,12 +41,10 @@ def _get_open_pr_tasks(app: App, repository) -> list:
     if app.pr_matches is None:
         raise ValueError(_ADO_PR_MATCHES_NONE_MSG)
     if repository:
-        repository_id = repository.id
-
-        def repo_query_func(record):
-            return record.get("ado_repository_id") == repository_id and record.get("processing_state", "open") != "closed"
-
-        tasks = app.pr_matches.search(repo_query_func)
+        tasks = app.pr_matches.search_by_json_fields(
+            {"ado_repository_id": repository.id},
+            {"processing_state": "closed"},
+        )
         _LOGGER.info(
             "Second pass: processing repository %s (ID: %s) open database PR tasks not handled in active PR sync",
             repository.name,
@@ -56,11 +54,7 @@ def _get_open_pr_tasks(app: App, repository) -> list:
             pr_task_info = [(task.get("ado_pr_id"), task.get("ado_repository_id")) for task in tasks]
             _LOGGER.debug("Second pass: Found PR tasks for repository %s: %s", repository.name, pr_task_info)
     else:
-
-        def all_query_func(record):
-            return record.get("processing_state", "open") != "closed"
-
-        tasks = app.pr_matches.search(all_query_func)
+        tasks = app.pr_matches.search_by_json_fields({}, {"processing_state": "closed"})
         _LOGGER.info("Second pass: processing all open database PR tasks not handled in active PR sync")
         _LOGGER.debug("Second pass: found %d open PR tasks in database", len(tasks))
     return tasks

--- a/ado_asana_sync/sync/pull_request_item.py
+++ b/ado_asana_sync/sync/pull_request_item.py
@@ -180,21 +180,29 @@ class PullRequestItem:
         if ado_pr_id is None and reviewer_gid is None and asana_gid is None:
             return None
 
-        query_func = cls._create_search_query(ado_pr_id, reviewer_gid, asana_gid)
+        if not app.pr_matches:
+            return None
 
-        if app.pr_matches and app.pr_matches.contains(query_func):
-            items = app.pr_matches.search(query_func)
-            if items:
-                # Remove doc_id before creating PullRequestItem
-                item_data = {k: v for k, v in items[0].items() if k != "doc_id"}
-                pr_item = cls(**item_data)
+        if ado_pr_id is not None and reviewer_gid is not None:
+            conditions = {"ado_pr_id": ado_pr_id, "reviewer_gid": reviewer_gid}
+        elif ado_pr_id is not None:
+            conditions = {"ado_pr_id": ado_pr_id}
+        elif reviewer_gid is not None:
+            conditions = {"reviewer_gid": reviewer_gid}
+        else:
+            conditions = {"asana_gid": asana_gid}
 
-                # Validate search result for corruption
-                if not cls._validate_search_result(pr_item, ado_pr_id, item_data):
-                    return None  # Don't return corrupted data
+        items = app.pr_matches.search_by_json_fields(conditions)
+        if not items:
+            return None
 
-                return pr_item
-        return None
+        item_data = {k: v for k, v in items[0].items() if k != "doc_id"}
+        pr_item = cls(**item_data)
+
+        if not cls._validate_search_result(pr_item, ado_pr_id, item_data):
+            return None
+
+        return pr_item
 
     def save(self, app: App) -> None:
         """
@@ -234,36 +242,21 @@ class PullRequestItem:
             "assignee_gid": self.assignee_gid,
         }
 
-        # Query for unique combination of PR ID and reviewer
-        def unique_query_func(record):
-            return record.get("ado_pr_id") == pr_data["ado_pr_id"] and record.get("reviewer_gid") == pr_data["reviewer_gid"]
-
         if app.pr_matches is None:
             raise ValueError("app.pr_matches is None")
         if app.db_lock is None:
             raise ValueError("app.db_lock is None")
 
-        # Use a larger critical section to ensure atomicity
         with app.db_lock:
-            # Clean up any corrupted records for this PR/reviewer combination first
             self._cleanup_corrupted_records(app, pr_data)
-
-            # Now save the current record
-            if app.pr_matches.contains(unique_query_func):
-                app.pr_matches.update(pr_data, unique_query_func)
-            else:
-                app.pr_matches.insert(pr_data)
+            app.pr_matches.upsert_by_json_fields(pr_data, {"ado_pr_id": self.ado_pr_id, "reviewer_gid": self.reviewer_gid})
 
     def _cleanup_corrupted_records(self, app: App, current_pr_data: dict) -> None:
         """Clean up corrupted records that don't match current data consistency."""
         if app.pr_matches is None:
             return
 
-        # Find all records for this PR ID
-        def pr_query_func(record):
-            return record.get("ado_pr_id") == current_pr_data["ado_pr_id"]
-
-        matching_records = app.pr_matches.search(pr_query_func)
+        matching_records = app.pr_matches.search_by_json_fields({"ado_pr_id": current_pr_data["ado_pr_id"]})
 
         # Handle case where matching_records might be None or empty, or a mock
         if not matching_records:
@@ -306,11 +299,9 @@ class PullRequestItem:
     def _remove_corrupted_record(self, app: App, record: dict) -> bool:
         """Remove a corrupted record from the database."""
         try:
-
-            def delete_query_func(r):
-                return r.get("ado_pr_id") == record.get("ado_pr_id") and r.get("reviewer_gid") == record.get("reviewer_gid")
-
-            app.pr_matches.remove(query_func=delete_query_func)  # type: ignore[arg-type,union-attr]
+            app.pr_matches.remove_by_json_fields(  # type: ignore[union-attr]
+                {"ado_pr_id": record.get("ado_pr_id"), "reviewer_gid": record.get("reviewer_gid")}
+            )
             return True
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger, _ = setup_logging_and_tracing(__name__)
@@ -365,11 +356,9 @@ class PullRequestItem:
     def _remove_corrupted_record_static(cls, app: App, record: dict) -> bool:
         """Remove a corrupted record from the database (static version)."""
         try:
-
-            def delete_query_func(r):
-                return r.get("ado_pr_id") == record.get("ado_pr_id") and r.get("reviewer_gid") == record.get("reviewer_gid")
-
-            app.pr_matches.remove(query_func=delete_query_func)  # type: ignore[arg-type,union-attr]
+            app.pr_matches.remove_by_json_fields(  # type: ignore[union-attr]
+                {"ado_pr_id": record.get("ado_pr_id"), "reviewer_gid": record.get("reviewer_gid")}
+            )
             return True
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger, _ = setup_logging_and_tracing(__name__)

--- a/ado_asana_sync/sync/task_item.py
+++ b/ado_asana_sync/sync/task_item.py
@@ -152,6 +152,10 @@ class TaskItem:
         if not app.matches:
             return None
 
+        # ado_id takes priority; asana_gid is only used as a fallback when ado_id
+        # finds nothing.  If ado_id returns a match there is no need to also
+        # search by asana_gid — both identifiers point to the same record once
+        # the initial sync has run.
         items = app.matches.search_by_json_fields({"ado_id": ado_id}) if ado_id is not None else []
         if not items and asana_gid is not None:
             items = app.matches.search_by_json_fields({"asana_gid": asana_gid})

--- a/ado_asana_sync/sync/task_item.py
+++ b/ado_asana_sync/sync/task_item.py
@@ -125,16 +125,12 @@ class TaskItem:
             TaskItem: The TaskItem object with the matching ADO ID.
             None: If there is no matching item.
         """
-
-        def query_func(record):
-            return record.get("ado_id") == ado_id
-
-        if app.matches and app.matches.contains(query_func):
-            items = app.matches.search(query_func)
-            if items:
-                # Remove doc_id before creating TaskItem
-                item_data = {k: v for k, v in items[0].items() if k != "doc_id"}
-                return cls(**item_data)
+        if not app.matches:
+            return None
+        items = app.matches.search_by_json_fields({"ado_id": ado_id})
+        if items:
+            item_data = {k: v for k, v in items[0].items() if k != "doc_id"}
+            return cls(**item_data)
         return None
 
     @classmethod
@@ -153,17 +149,16 @@ class TaskItem:
         if ado_id is None and asana_gid is None:
             return None
 
-        # Generate the query function based on the input.
-        def query_func(record):
-            return (record.get("ado_id") == ado_id) or (record.get("asana_gid") == asana_gid)
+        if not app.matches:
+            return None
 
-        # return the first matching item, or return None if not found.
-        if app.matches and app.matches.contains(query_func):
-            items = app.matches.search(query_func)
-            if items:
-                # Remove doc_id before creating TaskItem
-                item_data = {k: v for k, v in items[0].items() if k != "doc_id"}
-                return cls(**item_data)
+        items = app.matches.search_by_json_fields({"ado_id": ado_id}) if ado_id is not None else []
+        if not items and asana_gid is not None:
+            items = app.matches.search_by_json_fields({"asana_gid": asana_gid})
+
+        if items:
+            item_data = {k: v for k, v in items[0].items() if k != "doc_id"}
+            return cls(**item_data)
         return None
 
     def save(self, app: App) -> None:
@@ -191,18 +186,12 @@ class TaskItem:
             "due_date": self.due_date,
         }
 
-        def query_func(record):
-            return record.get("ado_id") == task_data["ado_id"]
-
         if app.matches is None:
             raise ValueError("app.matches is None")
 
         # SQLite database handles its own locking, but we maintain db_lock for compatibility
         with app.db_lock:
-            if app.matches.contains(query_func):
-                app.matches.update(task_data, query_func)
-            else:
-                app.matches.insert(task_data)
+            app.matches.upsert_by_json_fields(task_data, {"ado_id": self.ado_id})
 
     def is_current(self, app: App) -> bool:
         """

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -383,7 +383,7 @@ class TestDatabaseMigration(unittest.TestCase):
         db = Database(self.db_path)
 
         # Verify the migration was applied (schema version should be 2)
-        self.assertEqual(db.get_current_schema_version(), 2)
+        self.assertEqual(db.get_current_schema_version(), 3)
 
         # Verify the old data is still there
         projects = db.get_projects()
@@ -415,7 +415,7 @@ class TestDatabaseMigration(unittest.TestCase):
 
         # New database should be at current version
         current_version = db.get_current_schema_version()
-        self.assertEqual(current_version, 2)  # CURRENT_SCHEMA_VERSION
+        self.assertEqual(current_version, 3)  # CURRENT_SCHEMA_VERSION
 
         # Verify schema_version table has the initial record
         with db.get_connection() as conn:
@@ -423,7 +423,7 @@ class TestDatabaseMigration(unittest.TestCase):
             records = cursor.fetchall()
 
             self.assertEqual(len(records), 1)
-            self.assertEqual(records[0][0], 2)  # version
+            self.assertEqual(records[0][0], 3)  # version
             self.assertEqual(records[0][1], "Initial schema creation")  # description
 
         db.close()
@@ -460,18 +460,20 @@ class TestDatabaseMigration(unittest.TestCase):
         db.close()
         db = Database(self.db_path)
 
-        # Should now be at version 2
+        # Should now be at current version
         current_version = db.get_current_schema_version()
-        self.assertEqual(current_version, 2)
+        self.assertEqual(current_version, 3)
 
-        # Verify migration was recorded
+        # Verify migrations were recorded (v2 composite constraint + v3 index fix)
         with db.get_connection() as conn:
             cursor = conn.execute("SELECT version, description FROM schema_version ORDER BY id")
             records = cursor.fetchall()
 
-            self.assertEqual(len(records), 1)
+            self.assertEqual(len(records), 2)
             self.assertEqual(records[0][0], 2)  # version
-            self.assertEqual(records[0][1], "Add composite unique constraint for projects table")  # description
+            self.assertEqual(records[0][1], "Add composite unique constraint for projects table")
+            self.assertEqual(records[1][0], 3)  # version
+            self.assertEqual(records[1][1], "Fix pr_matches index and add asana_gid, reviewer_gid indexes")
 
         # Verify data was preserved
         projects = db.get_projects()
@@ -688,7 +690,153 @@ class TestDatabaseWrapper(unittest.TestCase):
 
         db = Database(self.db_path)
         self.assertIsInstance(db.table("matches"), DatabaseTable)
-        self.assertEqual(CURRENT_SCHEMA_VERSION, 2)
+        self.assertEqual(CURRENT_SCHEMA_VERSION, 3)
+        db.close()
+
+    def test_search_by_json_fields_single_condition(self):
+        """Test search_by_json_fields with a single equality condition."""
+        db = Database(self.db_path)
+        table = db.table("matches")
+
+        table.insert({"ado_id": 10, "title": "Task A"})
+        table.insert({"ado_id": 20, "title": "Task B"})
+        table.insert({"ado_id": 30, "title": "Task C"})
+
+        results = table.search_by_json_fields({"ado_id": 20})
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["ado_id"], 20)
+        self.assertEqual(results[0]["title"], "Task B")
+        self.assertIn("doc_id", results[0])
+
+        db.close()
+
+    def test_search_by_json_fields_multiple_conditions(self):
+        """Test search_by_json_fields with multiple AND conditions."""
+        db = Database(self.db_path)
+        table = db.table("pr_matches")
+
+        table.insert({"ado_pr_id": 1, "reviewer_gid": "user-a", "title": "PR 1 - User A"})
+        table.insert({"ado_pr_id": 1, "reviewer_gid": "user-b", "title": "PR 1 - User B"})
+        table.insert({"ado_pr_id": 2, "reviewer_gid": "user-a", "title": "PR 2 - User A"})
+
+        results = table.search_by_json_fields({"ado_pr_id": 1, "reviewer_gid": "user-a"})
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "PR 1 - User A")
+
+        db.close()
+
+    def test_search_by_json_fields_exclude_conditions(self):
+        """Test search_by_json_fields with exclude conditions (NULL-safe inequality)."""
+        db = Database(self.db_path)
+        table = db.table("pr_matches")
+
+        table.insert({"ado_pr_id": 1, "processing_state": "open"})
+        table.insert({"ado_pr_id": 2, "processing_state": "closed"})
+        table.insert({"ado_pr_id": 3})  # No processing_state key
+
+        results = table.search_by_json_fields({}, {"processing_state": "closed"})
+
+        result_ids = {r["ado_pr_id"] for r in results}
+        self.assertIn(1, result_ids)
+        self.assertIn(3, result_ids)  # NULL is treated as not-excluded
+        self.assertNotIn(2, result_ids)
+
+        db.close()
+
+    def test_search_by_json_fields_no_results(self):
+        """Test search_by_json_fields returns empty list when no matches."""
+        db = Database(self.db_path)
+        table = db.table("matches")
+
+        table.insert({"ado_id": 1, "title": "Task A"})
+
+        results = table.search_by_json_fields({"ado_id": 999})
+
+        self.assertEqual(results, [])
+
+        db.close()
+
+    def test_update_by_json_fields(self):
+        """Test update_by_json_fields updates matching records."""
+        db = Database(self.db_path)
+        table = db.table("matches")
+
+        table.insert({"ado_id": 10, "title": "Old Title"})
+        table.insert({"ado_id": 20, "title": "Other Title"})
+
+        updated_ids = table.update_by_json_fields({"ado_id": 10, "title": "New Title"}, {"ado_id": 10})
+
+        self.assertEqual(len(updated_ids), 1)
+
+        results = table.search_by_json_fields({"ado_id": 10})
+        self.assertEqual(results[0]["title"], "New Title")
+
+        other = table.search_by_json_fields({"ado_id": 20})
+        self.assertEqual(other[0]["title"], "Other Title")
+
+        db.close()
+
+    def test_remove_by_json_fields(self):
+        """Test remove_by_json_fields removes matching records."""
+        db = Database(self.db_path)
+        table = db.table("matches")
+
+        table.insert({"ado_id": 10, "title": "Delete Me"})
+        table.insert({"ado_id": 20, "title": "Keep Me"})
+
+        removed_ids = table.remove_by_json_fields({"ado_id": 10})
+
+        self.assertEqual(len(removed_ids), 1)
+        self.assertEqual(len(table.all()), 1)
+        self.assertEqual(table.all()[0]["ado_id"], 20)
+
+        db.close()
+
+    def test_upsert_by_json_fields_insert(self):
+        """Test upsert_by_json_fields inserts when no match exists."""
+        db = Database(self.db_path)
+        table = db.table("matches")
+
+        row_id = table.upsert_by_json_fields({"ado_id": 10, "title": "New Task"}, {"ado_id": 10})
+
+        self.assertIsNotNone(row_id)
+        results = table.all()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["ado_id"], 10)
+
+        db.close()
+
+    def test_upsert_by_json_fields_update(self):
+        """Test upsert_by_json_fields updates when a match exists."""
+        db = Database(self.db_path)
+        table = db.table("matches")
+
+        original_id = table.insert({"ado_id": 10, "title": "Original"})
+        returned_id = table.upsert_by_json_fields({"ado_id": 10, "title": "Updated"}, {"ado_id": 10})
+
+        self.assertEqual(returned_id, original_id)
+        results = table.all()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "Updated")
+
+        db.close()
+
+    def test_migration_v3_fixes_pr_matches_index(self):
+        """Test that migration v3 drops the incorrect pr_id index and creates correct indexes."""
+        db = Database(self.db_path)
+
+        with db.get_connection() as conn:
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='index'")
+            index_names = {row[0] for row in cursor.fetchall()}
+
+            self.assertNotIn("idx_pr_matches_data", index_names)
+            self.assertIn("idx_pr_matches_ado_pr_id", index_names)
+            self.assertIn("idx_pr_matches_reviewer_gid", index_names)
+            self.assertIn("idx_matches_ado_id", index_names)
+            self.assertIn("idx_matches_asana_gid", index_names)
+
         db.close()
 
 

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -839,6 +839,48 @@ class TestDatabaseWrapper(unittest.TestCase):
 
         db.close()
 
+    def test_search_by_json_fields_uses_index(self):
+        """Verify that EXPLAIN QUERY PLAN shows index usage, not a full table scan."""
+        db = Database(self.db_path)
+        table = db.table("matches")
+
+        for i in range(5):
+            table.insert({"ado_id": i, "title": f"Task {i}"})
+
+        with db.get_connection() as conn:
+            rows = conn.execute(
+                "EXPLAIN QUERY PLAN SELECT id FROM matches WHERE json_extract(data, '$.ado_id') = ?",
+                (3,),
+            ).fetchall()
+
+        # EXPLAIN QUERY PLAN columns: (id, parent, notused, detail)
+        plan_text = " ".join(row[3] for row in rows).upper()
+        self.assertIn("SEARCH", plan_text, "Expected SEARCH (index scan), not SCAN (full table scan)")
+        self.assertNotIn("SCAN MATCHES", plan_text, "Full table scan detected — index not being used")
+
+        db.close()
+
+    def test_pr_matches_search_by_ado_pr_id_uses_index(self):
+        """Verify that EXPLAIN QUERY PLAN shows index usage on pr_matches for ado_pr_id."""
+        db = Database(self.db_path)
+        table = db.table("pr_matches")
+
+        for i in range(5):
+            table.insert({"ado_pr_id": i, "reviewer_gid": f"gid-{i}"})
+
+        with db.get_connection() as conn:
+            rows = conn.execute(
+                "EXPLAIN QUERY PLAN SELECT id FROM pr_matches WHERE json_extract(data, '$.ado_pr_id') = ?",
+                (2,),
+            ).fetchall()
+
+        # EXPLAIN QUERY PLAN columns: (id, parent, notused, detail)
+        plan_text = " ".join(row[3] for row in rows).upper()
+        self.assertIn("SEARCH", plan_text, "Expected SEARCH (index scan), not SCAN (full table scan)")
+        self.assertNotIn("SCAN PR_MATCHES", plan_text, "Full table scan detected — index not being used")
+
+        db.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sync/test_pr_id_title_mismatch.py
+++ b/tests/sync/test_pr_id_title_mismatch.py
@@ -209,8 +209,7 @@ class TestPRIdTitleMismatch(unittest.TestCase):
             }
         ]
 
-        self.mock_app.pr_matches.contains.return_value = True
-        self.mock_app.pr_matches.search.return_value = mock_search_results
+        self.mock_app.pr_matches.search_by_json_fields.return_value = mock_search_results
 
         # Search for specific PR and reviewer combination
         result = PullRequestItem.search(self.mock_app, ado_pr_id=100, reviewer_gid="reviewer-gid-1")
@@ -238,8 +237,7 @@ class TestPRIdTitleMismatch(unittest.TestCase):
             }
         ]
 
-        self.mock_app.pr_matches.contains.return_value = True
-        self.mock_app.pr_matches.search.return_value = corrupted_search_results
+        self.mock_app.pr_matches.search_by_json_fields.return_value = corrupted_search_results
 
         # Search for specific PR ID but get back wrong data
         result = PullRequestItem.search(
@@ -392,9 +390,7 @@ class TestPRIdTitleMismatch(unittest.TestCase):
             }
         ]
 
-        self.mock_app.pr_matches.search.return_value = corrupted_records
-        self.mock_app.pr_matches.contains.return_value = False  # No existing record for new item
-        self.mock_app.pr_matches.remove = Mock()
+        self.mock_app.pr_matches.search_by_json_fields.return_value = corrupted_records
 
         # Create a valid PR item to save
         valid_pr_item = PullRequestItem(
@@ -410,9 +406,10 @@ class TestPRIdTitleMismatch(unittest.TestCase):
         # Save the valid item (should trigger cleanup)
         valid_pr_item.save(self.mock_app)
 
-        # Verify that the corrupted record was removed
-        self.mock_app.pr_matches.remove.assert_called()
-        self.mock_app.pr_matches.insert.assert_called_once()
+        # Verify that the corrupted record was removed via remove_by_json_fields
+        self.mock_app.pr_matches.remove_by_json_fields.assert_called()
+        # Verify that the valid item was saved via upsert
+        self.mock_app.pr_matches.upsert_by_json_fields.assert_called_once()
 
     def test_corrupted_data_cleanup_startup(self):
         """Test the startup cleanup of all corrupted records."""
@@ -441,14 +438,13 @@ class TestPRIdTitleMismatch(unittest.TestCase):
         ]
 
         self.mock_app.pr_matches.all.return_value = corrupted_records
-        self.mock_app.pr_matches.remove = Mock()
 
         # Run startup cleanup
         cleaned_count = PullRequestItem.cleanup_all_corrupted_records(self.mock_app)
 
         # Should clean up only the corrupted record
         self.assertEqual(cleaned_count, 1)
-        self.mock_app.pr_matches.remove.assert_called_once()
+        self.mock_app.pr_matches.remove_by_json_fields.assert_called_once()
 
     def test_asana_title_property_immutability(self):
         """Test that asana_title property always reflects current object state."""

--- a/tests/sync/test_pull_request_item.py
+++ b/tests/sync/test_pull_request_item.py
@@ -239,24 +239,36 @@ class TestPullRequestItem(unittest.TestCase):
         self.assertEqual(result.title, "Documentation update")
 
     def test_save_new_item(self):
-        """Test saving a new PullRequestItem uses upsert."""
+        """Test saving a new PullRequestItem passes correct data and conditions to upsert."""
+        self.mock_app.pr_matches.search_by_json_fields.return_value = []
+
         self.pr_item.save(self.mock_app)
 
         self.mock_app.pr_matches.upsert_by_json_fields.assert_called_once()
-        call_data = self.mock_app.pr_matches.upsert_by_json_fields.call_args[0][0]
+        call_data, call_conditions = self.mock_app.pr_matches.upsert_by_json_fields.call_args[0]
         self.assertEqual(call_data["ado_pr_id"], 123)
         self.assertEqual(call_data["reviewer_gid"], "asana-user-789")
         self.assertEqual(call_data["reviewer_name"], "Dan Anstis")
+        self.assertEqual(call_conditions, {"ado_pr_id": 123, "reviewer_gid": "asana-user-789"})
 
     def test_save_existing_item(self):
-        """Test saving an existing PullRequestItem uses upsert."""
+        """Test that save runs cleanup against existing DB records before upserting."""
+        existing_record = {
+            "ado_pr_id": 123,
+            "reviewer_gid": "asana-user-789",
+            "reviewer_name": "Dan Anstis",
+        }
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [existing_record]
+
         self.pr_item.save(self.mock_app)
 
+        # Cleanup searched for all records with this PR ID
+        self.mock_app.pr_matches.search_by_json_fields.assert_called_with({"ado_pr_id": 123})
+        # Upsert still runs to persist the latest data
         self.mock_app.pr_matches.upsert_by_json_fields.assert_called_once()
         call_data = self.mock_app.pr_matches.upsert_by_json_fields.call_args[0][0]
         self.assertEqual(call_data["ado_pr_id"], 123)
         self.assertEqual(call_data["reviewer_gid"], "asana-user-789")
-        self.assertEqual(call_data["reviewer_name"], "Dan Anstis")
 
     @patch("ado_asana_sync.sync.pull_request_item.get_asana_task")
     def test_is_current_true(self, mock_get_asana_task):

--- a/tests/sync/test_pull_request_item.py
+++ b/tests/sync/test_pull_request_item.py
@@ -127,9 +127,7 @@ class TestPullRequestItem(unittest.TestCase):
 
     def test_search_by_pr_id_and_reviewer(self):
         """Test searching by PR ID and reviewer GID."""
-        # Setup mocks
-        self.mock_app.pr_matches.contains.return_value = True
-        self.mock_app.pr_matches.search.return_value = [
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [
             {
                 "ado_pr_id": 123,
                 "ado_repository_id": "repo-456",
@@ -154,7 +152,7 @@ class TestPullRequestItem(unittest.TestCase):
 
     def test_search_not_found(self):
         """Test searching when no match is found."""
-        self.mock_app.pr_matches.contains.return_value = False
+        self.mock_app.pr_matches.search_by_json_fields.return_value = []
 
         result = PullRequestItem.search(self.mock_app, ado_pr_id=999)
 
@@ -167,8 +165,7 @@ class TestPullRequestItem(unittest.TestCase):
 
     def test_search_by_pr_id_only(self):
         """Test searching by PR ID only."""
-        self.mock_app.pr_matches.contains.return_value = True
-        self.mock_app.pr_matches.search.return_value = [
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [
             {
                 "ado_pr_id": 456,
                 "ado_repository_id": "repo-789",
@@ -193,8 +190,7 @@ class TestPullRequestItem(unittest.TestCase):
 
     def test_search_by_reviewer_gid_only(self):
         """Test searching by reviewer GID only."""
-        self.mock_app.pr_matches.contains.return_value = True
-        self.mock_app.pr_matches.search.return_value = [
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [
             {
                 "ado_pr_id": 789,
                 "ado_repository_id": "repo-123",
@@ -219,8 +215,7 @@ class TestPullRequestItem(unittest.TestCase):
 
     def test_search_by_asana_gid_only(self):
         """Test searching by Asana GID only."""
-        self.mock_app.pr_matches.contains.return_value = True
-        self.mock_app.pr_matches.search.return_value = [
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [
             {
                 "ado_pr_id": 999,
                 "ado_repository_id": "repo-555",
@@ -244,32 +239,24 @@ class TestPullRequestItem(unittest.TestCase):
         self.assertEqual(result.title, "Documentation update")
 
     def test_save_new_item(self):
-        """Test saving a new PullRequestItem."""
-        # Setup mocks
-        self.mock_app.pr_matches.contains.return_value = False
-
+        """Test saving a new PullRequestItem uses upsert."""
         self.pr_item.save(self.mock_app)
 
-        # Verify insert was called
-        self.mock_app.pr_matches.insert.assert_called_once()
-        call_args = self.mock_app.pr_matches.insert.call_args[0][0]
-        self.assertEqual(call_args["ado_pr_id"], 123)
-        self.assertEqual(call_args["reviewer_gid"], "asana-user-789")
-        self.assertEqual(call_args["reviewer_name"], "Dan Anstis")
+        self.mock_app.pr_matches.upsert_by_json_fields.assert_called_once()
+        call_data = self.mock_app.pr_matches.upsert_by_json_fields.call_args[0][0]
+        self.assertEqual(call_data["ado_pr_id"], 123)
+        self.assertEqual(call_data["reviewer_gid"], "asana-user-789")
+        self.assertEqual(call_data["reviewer_name"], "Dan Anstis")
 
     def test_save_existing_item(self):
-        """Test saving an existing PullRequestItem."""
-        # Setup mocks
-        self.mock_app.pr_matches.contains.return_value = True
-
+        """Test saving an existing PullRequestItem uses upsert."""
         self.pr_item.save(self.mock_app)
 
-        # Verify update was called
-        self.mock_app.pr_matches.update.assert_called_once()
-        call_args = self.mock_app.pr_matches.update.call_args[0][0]
-        self.assertEqual(call_args["ado_pr_id"], 123)
-        self.assertEqual(call_args["reviewer_gid"], "asana-user-789")
-        self.assertEqual(call_args["reviewer_name"], "Dan Anstis")
+        self.mock_app.pr_matches.upsert_by_json_fields.assert_called_once()
+        call_data = self.mock_app.pr_matches.upsert_by_json_fields.call_args[0][0]
+        self.assertEqual(call_data["ado_pr_id"], 123)
+        self.assertEqual(call_data["reviewer_gid"], "asana-user-789")
+        self.assertEqual(call_data["reviewer_name"], "Dan Anstis")
 
     @patch("ado_asana_sync.sync.pull_request_item.get_asana_task")
     def test_is_current_true(self, mock_get_asana_task):
@@ -353,10 +340,6 @@ class TestPullRequestItem(unittest.TestCase):
 
     def test_search_filters_doc_id_from_database_results(self):
         """Regression test: Ensure doc_id is filtered out when creating PullRequestItem from database results."""
-        # Setup mocks
-        self.mock_app.pr_matches.contains.return_value = True
-
-        # Mock database result that includes doc_id (this would cause constructor error if not filtered)
         mock_db_result = {
             "ado_pr_id": 789,
             "ado_repository_id": "repo-789",
@@ -372,23 +355,17 @@ class TestPullRequestItem(unittest.TestCase):
             "review_status": "waiting_for_author",
             "doc_id": 888,  # This should be filtered out
         }
-        self.mock_app.pr_matches.search.return_value = [mock_db_result]
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [mock_db_result]
 
-        # This should not raise an error about unexpected doc_id argument
         result = PullRequestItem.search(self.mock_app, ado_pr_id=789)
 
         self.assertIsNotNone(result)
         self.assertEqual(result.ado_pr_id, 789)
         self.assertEqual(result.title, "Test PR")
-        # Verify doc_id is not present in the created object
         self.assertFalse(hasattr(result, "doc_id"))
 
     def test_search_with_multiple_criteria_filters_doc_id(self):
         """Regression test: Ensure doc_id filtering works with multiple search criteria."""
-        # Setup mocks
-        self.mock_app.pr_matches.contains.return_value = True
-
-        # Mock database result with doc_id
         mock_db_result = {
             "ado_pr_id": 999,
             "ado_repository_id": "repo-999",
@@ -400,15 +377,13 @@ class TestPullRequestItem(unittest.TestCase):
             "asana_gid": "asana-999",
             "doc_id": 111,  # This should be filtered out
         }
-        self.mock_app.pr_matches.search.return_value = [mock_db_result]
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [mock_db_result]
 
-        # Test search with both PR ID and reviewer GID
         result = PullRequestItem.search(self.mock_app, ado_pr_id=999, reviewer_gid="reviewer-456")
 
         self.assertIsNotNone(result)
         self.assertEqual(result.ado_pr_id, 999)
         self.assertEqual(result.reviewer_gid, "reviewer-456")
-        # Verify doc_id is not present in the created object
         self.assertFalse(hasattr(result, "doc_id"))
 
     def test_save_with_none_app_pr_matches_raises_error(self):
@@ -434,9 +409,8 @@ class TestPullRequestItem(unittest.TestCase):
         self.assertIn("app.db_lock is None", str(context.exception))
 
     def test_search_returns_none_when_no_items_found(self):
-        """Test search returns None when pr_matches.search returns empty list."""
-        self.mock_app.pr_matches.contains.return_value = True
-        self.mock_app.pr_matches.search.return_value = []
+        """Test search returns None when search_by_json_fields returns empty list."""
+        self.mock_app.pr_matches.search_by_json_fields.return_value = []
 
         result = PullRequestItem.search(self.mock_app, ado_pr_id=123)
 
@@ -553,10 +527,6 @@ class TestPullRequestItem(unittest.TestCase):
 
     def test_search_query_logic_comprehensive(self):
         """Test the search query logic comprehensively."""
-        # Setup mocks with different scenarios
-        self.mock_app.pr_matches.contains.return_value = True
-
-        # Test case: Search with PR ID and reviewer GID (both match)
         mock_db_result = {
             "ado_pr_id": 123,
             "ado_repository_id": "repo-456",
@@ -567,9 +537,8 @@ class TestPullRequestItem(unittest.TestCase):
             "reviewer_name": "Test Reviewer",
             "asana_gid": "asana-123",
         }
-        self.mock_app.pr_matches.search.return_value = [mock_db_result]
+        self.mock_app.pr_matches.search_by_json_fields.return_value = [mock_db_result]
 
-        # This should find the item because both PR ID and reviewer GID match
         result = PullRequestItem.search(self.mock_app, ado_pr_id=123, reviewer_gid="reviewer-789")
         self.assertIsNotNone(result)
         self.assertEqual(result.ado_pr_id, 123)

--- a/tests/sync/test_pull_request_sync.py
+++ b/tests/sync/test_pull_request_sync.py
@@ -455,7 +455,7 @@ class TestPullRequestSync(unittest.TestCase):
             },
         ]
 
-        self.mock_app.pr_matches.search.return_value = existing_tasks
+        self.mock_app.pr_matches.search_by_json_fields.return_value = existing_tasks
         current_reviewers = {"current-user-gid"}  # Only one current reviewer
 
         handle_removed_reviewers(self.mock_app, mock_pr, current_reviewers, "test-project")
@@ -736,7 +736,7 @@ class TestPullRequestSync(unittest.TestCase):
                 "doc_id": 555,  # This should be filtered out
             }
         ]
-        mock_pr_matches.search.return_value = mock_db_results
+        mock_pr_matches.search_by_json_fields.return_value = mock_db_results
 
         current_reviewer_gids = ["active-reviewer-456"]  # removed-reviewer-123 is not in this list
 
@@ -778,7 +778,7 @@ class TestPullRequestSync(unittest.TestCase):
                 "doc_id": 333,  # This should be filtered out
             }
         ]
-        mock_app.pr_matches.search.return_value = mock_pr_data
+        mock_app.pr_matches.search_by_json_fields.return_value = mock_pr_data
 
         # Mock required parameters
         asana_users = []
@@ -994,33 +994,19 @@ class TestPullRequestSync(unittest.TestCase):
         mock_project.id = "project-456"
         mock_repo.project = mock_project
 
-        # Mock search to return only repo-2 PRs
-        def search_side_effect(query_func):
-            all_tasks = [
-                {
-                    "ado_pr_id": 100,
-                    "ado_repository_id": "repo-1",
-                    "title": "Active PR",
-                    "status": "active",
-                    "url": "https://example.com/pr/100",
-                    "reviewer_gid": "reviewer-1",
-                    "reviewer_name": "Test User 1",
-                    "asana_gid": "task-1",
-                },
-                {
-                    "ado_pr_id": 200,
-                    "ado_repository_id": "repo-2",
-                    "title": "Closed PR",
-                    "status": "completed",
-                    "url": "https://example.com/pr/200",
-                    "reviewer_gid": "reviewer-2",
-                    "reviewer_name": "Test User 2",
-                    "asana_gid": "task-2",
-                },
-            ]
-            return [task for task in all_tasks if query_func(task)]
-
-        mock_app.pr_matches.search.side_effect = search_side_effect
+        # search_by_json_fields returns only repo-2 tasks (filtering done by SQL in production)
+        mock_app.pr_matches.search_by_json_fields.return_value = [
+            {
+                "ado_pr_id": 200,
+                "ado_repository_id": "repo-2",
+                "title": "Closed PR",
+                "status": "completed",
+                "url": "https://example.com/pr/200",
+                "reviewer_gid": "reviewer-2",
+                "reviewer_name": "Test User 2",
+                "asana_gid": "task-2",
+            }
+        ]
 
         # Call function with processed_pr_ids containing PR 100
         process_closed_pull_requests(mock_app, [], "project-456", {100}, mock_repo)
@@ -1038,7 +1024,7 @@ class TestPullRequestSync(unittest.TestCase):
 
         # Mock empty database
         mock_app = Mock()
-        mock_app.pr_matches.search.return_value = []
+        mock_app.pr_matches.search_by_json_fields.return_value = []
 
         # Should not raise exception with None parameter
         try:
@@ -1080,11 +1066,9 @@ class TestPullRequestSync(unittest.TestCase):
             },
         ]
 
-        # Mock search to return only repo-1 tasks when filtered
-        def search_side_effect(query_func):
-            return [task for task in all_tasks if query_func(task)]
-
-        mock_app.pr_matches.search.side_effect = search_side_effect
+        # search_by_json_fields returns only repo-1 tasks (SQL filtering done at the DB level)
+        repo1_tasks = [task for task in all_tasks if task["ado_repository_id"] == "repo-1"]
+        mock_app.pr_matches.search_by_json_fields.return_value = repo1_tasks
         mock_app.pr_matches.all.return_value = all_tasks
         mock_app.ado_git_client.get_pull_request_by_id.return_value = Mock(status="completed")
         mock_app.asana_tag_gid = "tag-123"
@@ -1129,7 +1113,7 @@ class TestPullRequestSync(unittest.TestCase):
             }
         ]
         mock_app.pr_matches.all.return_value = pr_tasks
-        mock_app.pr_matches.search.return_value = pr_tasks
+        mock_app.pr_matches.search_by_json_fields.return_value = pr_tasks
 
         # Mock API to throw the exact error we encountered
         mock_app.ado_git_client.get_pull_request_by_id.side_effect = Exception(
@@ -1175,7 +1159,7 @@ class TestPullRequestSync(unittest.TestCase):
             }
         ]
         mock_app.pr_matches.all.return_value = pr_tasks
-        mock_app.pr_matches.search.return_value = pr_tasks
+        mock_app.pr_matches.search_by_json_fields.return_value = pr_tasks
 
         # Mock API to return abandoned PR
         mock_abandoned_pr = Mock()
@@ -1227,7 +1211,7 @@ class TestPullRequestSync(unittest.TestCase):
             }
         ]
         mock_app.pr_matches.all.return_value = pr_tasks
-        mock_app.pr_matches.search.return_value = pr_tasks
+        mock_app.pr_matches.search_by_json_fields.return_value = pr_tasks
 
         # Mock API to return draft PR
         mock_draft_pr = Mock()
@@ -1264,7 +1248,7 @@ class TestPullRequestSync(unittest.TestCase):
 
         # Mock empty database
         mock_app = Mock()
-        mock_app.pr_matches.search.return_value = []
+        mock_app.pr_matches.search_by_json_fields.return_value = []
 
         # Should not raise exception with None repository
         try:
@@ -1301,7 +1285,7 @@ class TestPullRequestSync(unittest.TestCase):
                 "review_status": "noVote",  # Old vote status
             }
         ]
-        mock_app.pr_matches.search.return_value = pr_tasks
+        mock_app.pr_matches.search_by_json_fields.return_value = pr_tasks
         mock_app.asana_tag_gid = "tag-123"
 
         # Mock completed PR
@@ -1381,7 +1365,7 @@ class TestPullRequestSync(unittest.TestCase):
                 "review_status": "waitingForAuthor",
             }
         ]
-        mock_app.pr_matches.search.return_value = pr_tasks
+        mock_app.pr_matches.search_by_json_fields.return_value = pr_tasks
         mock_app.asana_tag_gid = "tag-123"
 
         # Mock completed PR

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -300,8 +300,7 @@ class TestSyncItemAndChildrenLogging(unittest.TestCase):
     def test_log_when_user_not_matched(self):
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = False
-        app.matches.search.return_value = []
+        app.matches.search_by_json_fields.return_value = []
 
         ado_task = WorkItem()
         ado_task.id = 1
@@ -1101,8 +1100,7 @@ class TestSyncItemAndChildrenRecursion(unittest.TestCase):
         # Setup mocks
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = False  # No existing match
-        app.matches.search.return_value = []  # No existing match
+        app.matches.search_by_json_fields.return_value = []  # No existing match
 
         # Parent Item
         parent_task = WorkItem()

--- a/tests/sync/test_task_item.py
+++ b/tests/sync/test_task_item.py
@@ -42,11 +42,7 @@ class TestTaskItem(unittest.TestCase):
         app = MagicMock(App)
 
         app.matches = MagicMock()
-
-        # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = True
-        # Mock the search method of the matches table to return a mock TaskItem object
-        app.matches.search.return_value = [TEST_DB_ITEM_1]
+        app.matches.search_by_json_fields.return_value = [TEST_DB_ITEM_1]
 
         # Call the find_by_ado_id method with a valid ADO ID
         result = TaskItem.find_by_ado_id(app, 1)
@@ -69,9 +65,7 @@ class TestTaskItem(unittest.TestCase):
         app = MagicMock(App)
 
         app.matches = MagicMock()
-
-        # Mock the contains method of the matches table to return False
-        app.matches.contains.return_value = False
+        app.matches.search_by_json_fields.return_value = []
 
         # Call the find_by_ado_id method with a non-existing ADO ID
         result = TaskItem.find_by_ado_id(app, 1)
@@ -98,11 +92,7 @@ class TestTaskItem(unittest.TestCase):
         app = MagicMock(App)
 
         app.matches = MagicMock()
-
-        # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = True
-        # Mock the search method of the matches table to return a mock TaskItem object
-        app.matches.search.return_value = [TEST_DB_ITEM_1]
+        app.matches.search_by_json_fields.return_value = [TEST_DB_ITEM_1]
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, ado_id=1)
@@ -115,13 +105,9 @@ class TestTaskItem(unittest.TestCase):
         app = MagicMock(App)
 
         app.matches = MagicMock()
+        app.matches.search_by_json_fields.return_value = [TEST_DB_ITEM_1]
 
-        # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = True
-        # Mock the search method of the matches table to return a mock TaskItem object
-        app.matches.search.return_value = [TEST_DB_ITEM_1]
-
-        # Call the search method with an ado_id.
+        # Call the search method with an asana_gid.
         result = TaskItem.search(app, asana_gid="123456")
 
         self.assertEqual(result, TEST_TASK_ITEM_1)
@@ -132,9 +118,7 @@ class TestTaskItem(unittest.TestCase):
         app = MagicMock(App)
 
         app.matches = MagicMock()
-
-        # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = False
+        app.matches.search_by_json_fields.return_value = []
 
         # Call the search method with an ado_id.
         result = TaskItem.search(app, ado_id=5)
@@ -147,11 +131,9 @@ class TestTaskItem(unittest.TestCase):
         app = MagicMock(App)
 
         app.matches = MagicMock()
+        app.matches.search_by_json_fields.return_value = []
 
-        # Mock the contains method of the matches table to return True
-        app.matches.contains.return_value = False
-
-        # Call the search method with an ado_id.
+        # Call the search method with an asana_gid.
         result = TaskItem.search(app, asana_gid="987654")
 
         self.assertIsNone(result)
@@ -160,7 +142,6 @@ class TestTaskItem(unittest.TestCase):
         """Regression test: Ensure doc_id is filtered out when creating TaskItem from database results."""
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = True
 
         # Mock database result that includes doc_id (this would cause constructor error if not filtered)
         mock_db_result = {
@@ -176,7 +157,7 @@ class TestTaskItem(unittest.TestCase):
             "updated_date": "2023-12-01T10:00:00Z",
             "doc_id": 999,  # This should be filtered out
         }
-        app.matches.search.return_value = [mock_db_result]
+        app.matches.search_by_json_fields.return_value = [mock_db_result]
 
         # This should not raise an error about unexpected doc_id argument
         result = TaskItem.search(app, ado_id=123)
@@ -191,7 +172,6 @@ class TestTaskItem(unittest.TestCase):
         """Regression test: Ensure doc_id is filtered out in find_by_ado_id method."""
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = True
 
         # Mock database result with doc_id
         mock_db_result = {
@@ -202,7 +182,7 @@ class TestTaskItem(unittest.TestCase):
             "url": "https://example.com/456",
             "doc_id": 777,  # This should be filtered out
         }
-        app.matches.search.return_value = [mock_db_result]
+        app.matches.search_by_json_fields.return_value = [mock_db_result]
 
         # This should not raise an error about unexpected doc_id argument
         result = TaskItem.find_by_ado_id(app, 456)
@@ -214,32 +194,29 @@ class TestTaskItem(unittest.TestCase):
         self.assertFalse(hasattr(result, "doc_id"))
 
     def test_search_returns_none_when_items_list_empty(self):
-        """Test that search returns None when matches.search returns empty list."""
+        """Test that search returns None when search_by_json_fields returns empty list."""
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = True
-        app.matches.search.return_value = []  # Empty list
+        app.matches.search_by_json_fields.return_value = []
 
         result = TaskItem.search(app, ado_id=123)
 
         self.assertIsNone(result)
 
     def test_find_by_ado_id_returns_none_when_items_list_empty(self):
-        """Test that find_by_ado_id returns None when matches.search returns empty list."""
+        """Test that find_by_ado_id returns None when search_by_json_fields returns empty list."""
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = True
-        app.matches.search.return_value = []  # Empty list
+        app.matches.search_by_json_fields.return_value = []
 
         result = TaskItem.find_by_ado_id(app, 123)
 
         self.assertIsNone(result)
 
     def test_save_new_item(self):
-        """Test saving a new TaskItem."""
+        """Test saving a new TaskItem uses upsert."""
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = False
         app.db_lock = MagicMock()
         app.db_lock.__enter__ = MagicMock(return_value=app.db_lock)
         app.db_lock.__exit__ = MagicMock(return_value=None)
@@ -248,17 +225,17 @@ class TestTaskItem(unittest.TestCase):
 
         task_item.save(app)
 
-        # Verify insert was called
-        app.matches.insert.assert_called_once()
-        call_args = app.matches.insert.call_args[0][0]
-        self.assertEqual(call_args["ado_id"], 456)
-        self.assertEqual(call_args["title"], "New Task")
+        app.matches.upsert_by_json_fields.assert_called_once()
+        call_data = app.matches.upsert_by_json_fields.call_args[0][0]
+        self.assertEqual(call_data["ado_id"], 456)
+        self.assertEqual(call_data["title"], "New Task")
+        call_conditions = app.matches.upsert_by_json_fields.call_args[0][1]
+        self.assertEqual(call_conditions, {"ado_id": 456})
 
     def test_save_existing_item(self):
-        """Test saving an existing TaskItem."""
+        """Test saving an existing TaskItem uses upsert."""
         app = MagicMock()
         app.matches = MagicMock()
-        app.matches.contains.return_value = True
         app.db_lock = MagicMock()
         app.db_lock.__enter__ = MagicMock(return_value=app.db_lock)
         app.db_lock.__exit__ = MagicMock(return_value=None)
@@ -267,11 +244,10 @@ class TestTaskItem(unittest.TestCase):
 
         task_item.save(app)
 
-        # Verify update was called
-        app.matches.update.assert_called_once()
-        call_args = app.matches.update.call_args[0][0]
-        self.assertEqual(call_args["ado_id"], 789)
-        self.assertEqual(call_args["title"], "Updated Task")
+        app.matches.upsert_by_json_fields.assert_called_once()
+        call_data = app.matches.upsert_by_json_fields.call_args[0][0]
+        self.assertEqual(call_data["ado_id"], 789)
+        self.assertEqual(call_data["title"], "Updated Task")
 
     def test_save_with_none_app_matches_raises_error(self):
         """Test save raises ValueError when app.matches is None."""
@@ -552,14 +528,13 @@ class TestTaskItemDueDateContract(unittest.TestCase):
         mock_app.db_lock = MagicMock()
         mock_app.db_lock.__enter__ = MagicMock(return_value=mock_app.db_lock)
         mock_app.db_lock.__exit__ = MagicMock(return_value=None)
-        mock_app.matches.contains.return_value = False
 
         # Call save method
         task.save(mock_app)
 
-        # Verify the insert was called with due_date included
-        mock_app.matches.insert.assert_called_once()
-        saved_data = mock_app.matches.insert.call_args[0][0]
+        # Verify upsert_by_json_fields was called with due_date included
+        mock_app.matches.upsert_by_json_fields.assert_called_once()
+        saved_data = mock_app.matches.upsert_by_json_fields.call_args[0][0]
         self.assertIn("due_date", saved_data)
         self.assertEqual(saved_data["due_date"], "2025-12-31")
 


### PR DESCRIPTION
## Summary

- Added `search_by_json_fields`, `update_by_json_fields`, `remove_by_json_fields`, and `upsert_by_json_fields` methods to `DatabaseTable` that use SQLite's `json_extract()` with parameterized queries, enabling the database engine to utilize indexes instead of performing full table scans
- Added database migration v3 to fix the incorrect `idx_pr_matches_data` index (was indexing `$.pr_id` which does not exist; fixed to `$.ado_pr_id`) and creates correct covering indexes on `ado_id`, `asana_gid`, `ado_pr_id`, and `reviewer_gid`
- Updated all hot-path callers (`task_item`, `pull_request_item`, `pr_sync_core`, `pr_processor`) to use the new SQL methods
- Added 9 new integration tests for the new SQL methods; all 373 tests pass

## Test plan

- [x] `uv run pytest tests/database/test_database.py` — verify migration v3 tests pass
- [x] `uv run pytest tests/sync/` — verify all sync tests pass with new mock interfaces
- [x] `uv run pytest` — full 373-test suite passes
- [x] `uv run ruff check .` — no lint errors
- [x] `uv run ruff format --check .` — no formatting issues
- [x] `uv run mypy ado_asana_sync/` — no type errors
- [x] Verify on a real database that EXPLAIN QUERY PLAN for search_by_json_fields shows index usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)