### PR TITLE
docs: address PR sync documentation gaps for E2E split and group reviewer strategies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Follow these steps to set up your development environment:
 - `ado_asana_sync/sync/task_factory.py`: Logic for building Asana task request bodies and saving newly created tasks.
 - `ado_asana_sync/sync/pull_request_item.py`: Defines the `PullRequestItem` data structure for PR-reviewer relationships.
 - `ado_asana_sync/sync/pr_sync_core.py`: PR sync orchestration (`sync_pull_requests`, `process_repository_pull_requests`, `process_closed_pull_requests`).
-- `ado_asana_sync/sync/pr_processor.py`: Logic for processing individual PRs and reviewers (`process_pull_request`, `handle_removed_reviewers`, `process_pr_reviewer`).
+- `ado_asana_sync/sync/pr_processor.py`: Logic for processing individual PRs and reviewers, including group-reviewer detection and fallback handling (`process_pull_request`, `process_pr_reviewer`, `handle_removed_reviewers`, `create_new_pr_reviewer_task`, `update_existing_pr_reviewer_task`, `is_group_reviewer`, `_handle_group_reviewer`).
 - `ado_asana_sync/sync/pr_asana_helpers.py`: Asana helpers specific to PRs (`create_asana_pr_task`, `update_asana_pr_task`, `add_tag_to_pr_task`, `add_closure_comment_to_pr_task`).
 - `ado_asana_sync/sync/pull_request_sync.py`: Re-export facade for backward compatibility.
 - `ado_asana_sync/sync/utils.py`: Shared utility functions (reviewer vote extraction, date conversion, URL encoding).
@@ -68,6 +68,11 @@ The E2E test suite lives in `tests/e2e/` and validates the complete sync workflo
 uv run pytest tests/e2e/ -v
 ```
 
+The suite is currently split across:
+
+- `tests/e2e/test_e2e_work_items.py`: work item sync scenarios
+- `tests/e2e/test_e2e_pull_requests.py`: pull request reviewer sync scenarios
+
 **Key principles for E2E tests:**
 
 - Use real `App` instances with real SQLite databases in temporary directories.
@@ -78,10 +83,20 @@ uv run pytest tests/e2e/ -v
 
 **Adding a new E2E scenario:**
 
-1. Add a test method to `TestE2ESyncWorkItems` (for work items) or `TestE2ESyncPullRequests` (for PRs) in `tests/e2e/test_e2e_sync.py`.
+1. Add a test method to `TestE2ESyncWorkItems` in `tests/e2e/test_e2e_work_items.py` (for work items) or `TestE2ESyncPullRequests` in `tests/e2e/test_e2e_pull_requests.py` (for PRs).
 1. Pre-seed DB if testing an update/close/reopen scenario using `app.matches.insert(...)`.
 1. Set up ADO mock responses via `mock_wit.get_work_item.return_value = ...`.
 1. Assert on `tasks_api.create_task` / `tasks_api.update_task` call arguments and on `app.matches.all()` / `app.pr_matches.all()` database state.
+
+### Group Reviewer Fallback Strategies
+
+ADO pull requests can include group/container reviewers such as `[Project]\\Contributors`. The sync behavior is controlled by `GROUP_REVIEWER_STRATEGY`:
+
+- `ignore`: skip group reviewers entirely. This is the default.
+- `default_user`: create or update the reviewer task and assign it to `GROUP_REVIEWER_DEFAULT_USER`. The fallback user can be resolved by Asana email, GID, or display name.
+- `unassigned_task`: create or update the reviewer task without an assignee, preserving the group name in the task title.
+
+If `GROUP_REVIEWER_STRATEGY=default_user` but `GROUP_REVIEWER_DEFAULT_USER` is unset or cannot be resolved, the group reviewer is skipped.
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ This repository provides a robust tool for synchronizing tasks between Azure Dev
   - `ado_asana_sync/sync/task_factory.py`: Logic for building Asana task request bodies and saving newly created tasks.
   - `ado_asana_sync/sync/pull_request_item.py`: Pull request data structure.
   - `ado_asana_sync/sync/pr_sync_core.py`: PR sync orchestration (top-level sync functions).
-  - `ado_asana_sync/sync/pr_processor.py`: Logic for processing individual PRs and reviewers.
+  - `ado_asana_sync/sync/pr_processor.py`: Logic for processing individual PRs and reviewers, including group-reviewer detection, fallback assignment strategies, and reviewer task create/update flows.
   - `ado_asana_sync/sync/pr_asana_helpers.py`: Asana API helpers specific to PRs.
   - `ado_asana_sync/sync/pull_request_sync.py`: Re-export facade for backward compatibility.
   - `ado_asana_sync/sync/utils.py`: Shared utility functions (reviewer vote extraction, date conversion, URL encoding).
@@ -231,6 +231,11 @@ This project uses **uv** for dependency management with `pyproject.toml` and `uv
 
 The `tests/e2e/` directory contains a comprehensive E2E test suite that validates the complete sync workflow using isolated temporary databases and mocked API endpoints. No real ADO or Asana credentials are required.
 
+The suite is currently split across:
+
+- `tests/e2e/test_e2e_work_items.py`: work item sync scenarios
+- `tests/e2e/test_e2e_pull_requests.py`: pull request reviewer sync scenarios
+
 ### Running E2E Tests
 
 ```bash
@@ -260,6 +265,16 @@ The E2E tests are included automatically in `uv run test` (the standard CI test 
 - **Mocked boundaries**: ADO clients (`app.ado_wit_client`, etc.) and Asana SDK classes (`asana.TasksApi`, etc.) are replaced with `MagicMock` via `unittest.mock.patch`.
 - **Pre-seeded DB**: Update/close/reopen scenarios insert a record into `app.matches` or `app.pr_matches` before running `sync_project` or `sync_pull_requests`.
 - **Assertions**: Verify Asana API call arguments (`tasks_api.create_task.call_args`) and real database state (`app.matches.all()`).
+
+## Group Reviewer Fallback Strategies
+
+ADO pull requests can include group or container reviewers such as `[Project]\\Contributors`. These do not map cleanly to a single user, so reviewer sync supports three fallback modes via `GROUP_REVIEWER_STRATEGY`:
+
+- `ignore`: skip group reviewers entirely. This is the default behavior.
+- `default_user`: create or update the reviewer task and assign it to `GROUP_REVIEWER_DEFAULT_USER`. Resolution accepts an Asana email, GID, or display name.
+- `unassigned_task`: create or update the reviewer task without an assignee, keeping the group name in the task title.
+
+If `default_user` is selected but `GROUP_REVIEWER_DEFAULT_USER` is empty or cannot be resolved, the group reviewer is skipped.
 
 ## Current Features
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cp .env.example .env
 - `THREAD_COUNT`: Number of projects to sync in parallel (default: `8`).
 - `SLEEP_TIME`: Seconds to sleep between sync runs (default: `300`).
 - `RUN_ONCE`: Run a single sync cycle and exit with a normal process status (default: `false`).
-- `DRY_RUN`: Compute and log planned create/update/close actions without writing to Asana or the local sync database (default: `false`).
+- `DRY_RUN`: Compute and log planned create/update/close actions without writing to Asana or the local sync database. The log summary includes separate create/update/close counts and ADO/PR IDs for both work items and PR reviewer tasks. Because no local mappings are persisted, repeated dry runs re-evaluate the same items from scratch (default: `false`).
 - `SYNC_THRESHOLD`: Days to continue syncing closed tasks before unmapping (default: `30`).
 - `SYNCED_TAG_NAME`: Asana tag appended to all synced items (default: `synced`).
 - `LOGLEVEL`: Console log level (default: `INFO`).
@@ -106,6 +106,8 @@ You can run the sync tool either locally using `uv` or via Docker.
    ```bash
    DRY_RUN=true RUN_ONCE=true uv run python -m ado_asana_sync.sync
    ```
+
+In dry-run mode, expect log-only output such as create/update/close summaries. No Asana writes are sent, and no new entries are saved to `data/appdata.db`.
 
 #### Option B: Running via Docker
 

--- a/docs/TESTING_EXAMPLES.md
+++ b/docs/TESTING_EXAMPLES.md
@@ -195,6 +195,80 @@ class TestPullRequestIntegration(unittest.TestCase):
                 app.close()
 ```
 
+### Integration Test - Pull Request Sync Workflow
+
+```python
+import tempfile
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+from tests.utils.test_helpers import AsanaApiMockHelper, RealObjectBuilder, TestDataBuilder
+
+
+@patch("ado_asana_sync.sync.app.os.path.dirname")
+@patch("ado_asana_sync.sync.app.Connection")
+@patch("ado_asana_sync.sync.app.asana.ApiClient")
+def test_sync_pull_requests_real_integration(mock_asana_client, mock_ado_conn, mock_dirname):
+    """
+    TRUE Integration Test: exercises the real PR sync workflow with a real App and DB.
+
+    What this tests:
+    - REAL App instance with REAL TinyDB tables
+    - REAL sync_pull_requests() orchestration across repositories, PRs, and reviewers
+    - REAL reviewer matching and PullRequestItem persistence
+    - Mocked ADO/Asana boundaries only
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        mock_dirname.return_value = temp_dir
+        mock_ado_conn.return_value = MagicMock()
+        mock_asana_client.return_value = MagicMock()
+
+        app = TestDataBuilder.create_real_app(temp_dir)
+        app.connect()
+        app.pr_sync_cache = {"custom_fields": {}, "asana_tasks": {}}
+
+        ado_project = MagicMock(id="proj-id", name="TestProject")
+        repo = RealObjectBuilder.create_real_ado_repository(repo_id="repo-abc", name="test-repo")
+        pr = RealObjectBuilder.create_real_ado_pull_request(pr_id=100, title="Add Feature X", status="active")
+        reviewer = RealObjectBuilder.create_real_ado_reviewer(
+            display_name="Test User", email="test@example.com", vote=0
+        )
+
+        mock_git = MagicMock()
+        mock_git.get_repositories.return_value = [repo]
+        mock_git.get_pull_requests.return_value = [pr]
+        mock_git.get_pull_request_reviewers.return_value = [reviewer]
+        app.ado_git_client = mock_git
+
+        asana_helper = AsanaApiMockHelper()
+        created_task = TestDataBuilder.create_asana_task_data(
+            gid="pr_task_gid_100", name="Pull Request 100: Add Feature X (Test User)"
+        )
+        tasks_api = asana_helper.create_tasks_api_mock(tasks=[], created_task=created_task)
+
+        try:
+            with ExitStack() as stack:
+                stack.enter_context(patch("ado_asana_sync.sync.pr_sync_core.asana.TasksApi", return_value=tasks_api))
+                stack.enter_context(
+                    patch(
+                        "ado_asana_sync.sync.pr_sync_core.asana.UsersApi",
+                        return_value=asana_helper.create_users_api_mock(),
+                    )
+                )
+                from ado_asana_sync.sync.pr_sync_core import sync_pull_requests
+
+                sync_pull_requests(app, ado_project, "workspace-123", "project-456")
+
+            tasks_api.create_task.assert_called_once()
+            pr_records = app.pr_matches.all()
+            assert pr_records[0]["ado_pr_id"] == 100
+            assert pr_records[0]["processing_state"] == "open"
+        finally:
+            app.close()
+```
+
+Use this pattern when you need to verify the full PR sync flow instead of only `process_pr_reviewer()` in isolation.
+
 ### Unit Test - Focused Individual Function
 
 ```python


### PR DESCRIPTION
### **User description**
## Summary
- update AGENTS.md and CLAUDE.md to reflect the split E2E files, group reviewer fallback strategies, and current PR processor responsibilities
- clarify README dry-run behavior, including the create/update/close summary output and the lack of local persistence
- add a concrete pull request sync integration example to docs/TESTING_EXAMPLES.md

## Why
The repository documentation had drifted behind the recent PR sync changes, which left agents and contributors with stale file paths, incomplete reviewer-strategy guidance, and unclear dry-run expectations.

Closes AAS-69

## Validation
- uv run mdformat --check AGENTS.md CLAUDE.md README.md docs/TESTING_EXAMPLES.md
- uv run check
- uv run test


___

### **PR Type**
Documentation


___

### **Description**
- Update `AGENTS.md` and `CLAUDE.md` with E2E test file split and group reviewer fallback strategies

- Clarify `DRY_RUN` behavior in `README.md` with log output details and persistence notes

- Add concrete PR sync integration test example to `docs/TESTING_EXAMPLES.md`

- Expand `pr_processor.py` descriptions to include group-reviewer detection functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AGENTS.md / CLAUDE.md"] -- "document E2E file split" --> B["test_e2e_work_items.py\ntest_e2e_pull_requests.py"]
  A -- "document group reviewer\nfallback strategies" --> C["GROUP_REVIEWER_STRATEGY\n(ignore / default_user / unassigned_task)"]
  D["README.md"] -- "clarify DRY_RUN behavior" --> E["Log-only output\nNo DB persistence"]
  F["docs/TESTING_EXAMPLES.md"] -- "add PR sync\nintegration example" --> G["sync_pull_requests()\nintegration test pattern"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Document E2E split and group reviewer fallback strategies</code></dd></summary>
<hr>

AGENTS.md

<ul><li>Expanded <code>pr_processor.py</code> description to include group-reviewer <br>detection and fallback functions<br> <li> Added note about E2E suite split across <code>test_e2e_work_items.py</code> and <br><code>test_e2e_pull_requests.py</code><br> <li> Updated "Adding a new E2E scenario" instructions to reference the <br>correct split files<br> <li> Added new "Group Reviewer Fallback Strategies" section documenting <br><code>GROUP_REVIEWER_STRATEGY</code> modes</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/684/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add group reviewer strategies and E2E file split docs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Expanded <code>pr_processor.py</code> description to include group-reviewer <br>detection and fallback assignment strategies<br> <li> Added note about E2E suite split across <code>test_e2e_work_items.py</code> and <br><code>test_e2e_pull_requests.py</code><br> <li> Added new "Group Reviewer Fallback Strategies" section with three <br>strategy modes and resolution behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/684/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+16/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify DRY_RUN behavior and log output details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Expanded <code>DRY_RUN</code> description to clarify log summary includes <br>create/update/close counts and IDs<br> <li> Added note that no local mappings are persisted in dry-run mode, <br>causing re-evaluation on each run<br> <li> Added inline note after dry-run example clarifying no Asana writes and <br>no <code>appdata.db</code> entries</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/684/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TESTING_EXAMPLES.md</strong><dd><code>Add PR sync integration test example to testing docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/TESTING_EXAMPLES.md

<ul><li>Added a new "Integration Test - Pull Request Sync Workflow" section <br>with a complete code example<br> <li> Example demonstrates real <code>App</code> instance, real TinyDB tables, and mocked <br>ADO/Asana boundaries<br> <li> Shows usage of <code>AsanaApiMockHelper</code>, <code>RealObjectBuilder</code>, and <br><code>TestDataBuilder</code> helpers<br> <li> Includes assertions on <code>tasks_api.create_task</code> and <code>app.pr_matches</code> <br>database state</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/684/files#diff-4d6a3c283915ec98ff71400e5df81308367f479cdc73f07da2ea88613d981bb2">+74/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

