### PR TITLE
docs: update database layer details and query guidelines in agent docs (AAS-76)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,20 @@ Follow these steps to set up your development environment:
 - `ado_asana_sync/sync/pr_asana_helpers.py`: Asana helpers specific to PRs (`create_asana_pr_task`, `update_asana_pr_task`, `add_tag_to_pr_task`, `add_closure_comment_to_pr_task`).
 - `ado_asana_sync/sync/pull_request_sync.py`: Re-export facade for backward compatibility.
 - `ado_asana_sync/sync/utils.py`: Shared utility functions (reviewer vote extraction, date conversion, URL encoding).
+- `ado_asana_sync/database/connection.py`: SQLite `Database` and `DatabaseTable` classes; exposes `search_by_json_fields`, `update_by_json_fields`, `upsert_by_json_fields`, and `remove_by_json_fields` for index-backed hot-path queries.
+- `ado_asana_sync/database/migrations.py`: `DatabaseMigrationsMixin` with schema versioning and migration helpers; currently at schema version 3 with indexes on `ado_id`, `asana_gid`, `ado_pr_id`, and `reviewer_gid`.
 - `data/projects.json.example`: Provides an example of the project data structure required for configuration.
+
+### Database Query Guidelines
+
+For **hot-path queries** that filter by indexed fields (`ado_id`, `asana_gid`, `ado_pr_id`, `reviewer_gid`), always use the SQL-backed methods on `DatabaseTable` instead of `.all()` or `.get()`. This avoids full table scans and prevents performance regressions as the database grows:
+
+- `table.search_by_json_fields({"ado_id": value})` — indexed lookup; use instead of `.all()` + manual filtering
+- `table.update_by_json_fields(data, {"ado_id": value})` — indexed update; use instead of `.update(data, query_func)`
+- `table.upsert_by_json_fields(data, {"ado_id": value})` — indexed upsert; use instead of `.upsert(data, query_func)`
+- `table.remove_by_json_fields({"ado_id": value})` — indexed delete; use instead of `.remove(query_func=...)`
+
+Reserve `.all()` for operations that genuinely require every row (e.g. bulk exports, test assertions on full state). Reserve `.search(query_func)` for complex predicates that cannot be expressed as simple equality conditions on indexed fields.
 
 ### Coding Conventions
 
@@ -138,7 +151,8 @@ If `GROUP_REVIEWER_STRATEGY=default_user` but `GROUP_REVIEWER_DEFAULT_USER` is u
   - `sync/pull_request_sync.py`: re-export facade for backward compatibility
   - `sync/utils.py`: shared utilities (vote extraction, date conversion, URL encoding)
   - `utils/`: logging/tracing, time helpers
-  - `database/`: SQLite persistence
+  - `database/connection.py`: `Database` and `DatabaseTable` classes (SQLite persistence)
+  - `database/migrations.py`: schema versioning and migration helpers
 - Config example: `data/projects.json.example`
 - Tests: `tests/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,21 @@ This repository provides a robust tool for synchronizing tasks between Azure Dev
   - `ado_asana_sync/sync/pr_asana_helpers.py`: Asana API helpers specific to PRs.
   - `ado_asana_sync/sync/pull_request_sync.py`: Re-export facade for backward compatibility.
   - `ado_asana_sync/sync/utils.py`: Shared utility functions (reviewer vote extraction, date conversion, URL encoding).
+  - `ado_asana_sync/database/connection.py`: SQLite `Database` and `DatabaseTable` classes; exposes `search_by_json_fields`, `update_by_json_fields`, `upsert_by_json_fields`, and `remove_by_json_fields` for index-backed hot-path queries.
+  - `ado_asana_sync/database/migrations.py`: `DatabaseMigrationsMixin` with schema versioning and migration helpers; currently at schema version 3 with indexes on `ado_id`, `asana_gid`, `ado_pr_id`, and `reviewer_gid`.
   - `data/projects.json.example`: Example project configuration.
+
+## Database Query Guidelines
+
+For **hot-path queries** that filter by indexed fields (`ado_id`, `asana_gid`, `ado_pr_id`, `reviewer_gid`), always use the SQL-backed methods on `DatabaseTable` instead of `.all()` or `.get()`. This avoids full table scans and prevents performance regressions as the database grows:
+
+- `table.search_by_json_fields({"ado_id": value})` — indexed lookup; use instead of `.all()` + manual filtering
+- `table.update_by_json_fields(data, {"ado_id": value})` — indexed update; use instead of `.update(data, query_func)`
+- `table.upsert_by_json_fields(data, {"ado_id": value})` — indexed upsert; use instead of `.upsert(data, query_func)`
+- `table.remove_by_json_fields({"ado_id": value})` — indexed delete; use instead of `.remove(query_func=...)`
+
+Reserve `.all()` for operations that genuinely require every row (e.g. bulk exports, test assertions on full state). Reserve `.search(query_func)` for complex predicates that cannot be expressed as simple equality conditions on indexed fields.
+
 - Write all code in Python.
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 - Enforce markdown formatting with `mdformat` for all `.md` files.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ You can run the sync tool either locally using `uv` or via Docker.
    ```bash
    uv run python -m ado_asana_sync.sync
    ```
+   Alternatively, use the installed script entry point defined in `pyproject.toml`:
+   ```bash
+   uv run ado-asana-sync
+   ```
 1. **Run a single dry-run or one-shot sync with inline variables:**
    ```bash
    DRY_RUN=true RUN_ONCE=true uv run python -m ado_asana_sync.sync


### PR DESCRIPTION
### **User description**
## Summary

- Added `ado_asana_sync/database/connection.py` and `migrations.py` to the **Main Components** and **Project Structure** sections of both `AGENTS.md` and `CLAUDE.md`
- Added a **Database Query Guidelines** section to both `AGENTS.md` and `CLAUDE.md` instructing agents to use `search_by_json_fields`, `update_by_json_fields`, `upsert_by_json_fields`, and `remove_by_json_fields` instead of `.all()` or `.get()` for hot-path queries on indexed fields (`ado_id`, `asana_gid`, `ado_pr_id`, `reviewer_gid`)
- Updated `README.md` to mention `uv run ado-asana-sync` as an alternative to `uv run python -m ado_asana_sync.sync`

## Test plan

- [ ] Verify `uv run mdformat --check *.md` passes (no formatting changes needed)
- [ ] Review that database component descriptions in AGENTS.md/CLAUDE.md accurately reflect `connection.py` and `migrations.py`
- [ ] Confirm the query guidance matches the actual `DatabaseTable` API

Closes [AAS-76](mention://issue/5a806883-a9e6-48a0-93c4-76cc7a2807f2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Added `connection.py` and `migrations.py` to component docs in `AGENTS.md`/`CLAUDE.md`

- Added Database Query Guidelines section with indexed field usage guidance

- Updated `README.md` with `uv run ado-asana-sync` script entry point alternative


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AGENTS.md / CLAUDE.md"] -- "Add component entries" --> B["database/connection.py\n& migrations.py"]
  A -- "Add section" --> C["Database Query Guidelines"]
  C -- "Prefer indexed methods" --> D["search_by_json_fields\nupdate_by_json_fields\nupsert_by_json_fields\nremove_by_json_fields"]
  E["README.md"] -- "Add alternative run command" --> F["uv run ado-asana-sync"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add database components and query guidelines to AGENTS.md</code></dd></summary>
<hr>

AGENTS.md

<ul><li>Added <code>connection.py</code> and <code>migrations.py</code> entries to Main Components <br>section<br> <li> Added Database Query Guidelines section with indexed field query <br>methods<br> <li> Expanded <code>database/</code> entry in Project Structure to list individual files</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/686/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add database components and query guidelines to CLAUDE.md</code></dd></summary>
<hr>

CLAUDE.md

<ul><li>Added <code>connection.py</code> and <code>migrations.py</code> entries to Main Components <br>section<br> <li> Added new Database Query Guidelines section with indexed field query <br>methods<br> <li> Guidance to avoid <code>.all()</code> and <code>.get()</code> for hot-path queries</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/686/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add alternative script entry point to README run instructions</code></dd></summary>
<hr>

README.md

<ul><li>Added mention of <code>uv run ado-asana-sync</code> as an alternative script entry <br>point<br> <li> References <code>pyproject.toml</code> as the source of the script definition</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/686/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

