### PR TITLE
fix(tests): replace hardcoded _RECENT_DATE with dynamic value (AAS-109)

### DIFF
--- a/tests/e2e/_shared.py
+++ b/tests/e2e/_shared.py
@@ -8,11 +8,12 @@ patching only external ADO/Asana client boundaries.
 import shutil
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from tests.utils.test_helpers import AsanaApiMockHelper
 
-_RECENT_DATE = "2026-05-30T10:00:00.000Z"
+_RECENT_DATE = (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 _OLD_ASANA_DATE = "2025-01-01T10:00:00.000Z"
 _TEST_USER_ASSIGNED = {"displayName": "Test User", "uniqueName": "test@example.com"}
 _ADO_BASE_URL = "https://dev.azure.com/test/project/_workitems/edit"


### PR DESCRIPTION
### **User description**
## Summary

- Replaced the hardcoded `_RECENT_DATE = "2026-05-30T10:00:00.000Z"` in `tests/e2e/_shared.py` with a dynamic value computed as `now - 2 days`
- The hardcoded date caused `is_item_older_than_threshold` to return `True` once 38 days had elapsed (>30-day threshold), skipping the Asana task update and failing `test_work_item_close_completes_asana_task`
- All 375 tests pass; lint, formatting, and type checks are clean

## Test plan

- [x] `test_work_item_close_completes_asana_task` now passes
- [x] Full test suite (375 tests) passes
- [x] `uv run check` passes (ruff lint, ruff format, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Replaced hardcoded `_RECENT_DATE` with dynamic value

- Computed as `now - 2 days` in UTC

- Fixes time-bomb test failure in `test_work_item_close_completes_asana_task`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded _RECENT_DATE (2026-05-30)"] -- "replaced with" --> B["Dynamic _RECENT_DATE (now - 2 days)"]
  B -- "prevents" --> C["Time-bomb test failure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_shared.py</strong><dd><code>Compute _RECENT_DATE dynamically instead of hardcoding</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/e2e/_shared.py

<ul><li>Imports <code>datetime</code>, <code>timedelta</code>, <code>timezone</code> from <code>datetime</code> module<br> <li> Replaces hardcoded <code>_RECENT_DATE</code> string with a dynamically computed <br>value<br> <li> New value is <code>now - 2 days</code> in UTC, formatted to match previous format</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/717/files#diff-21b53e023b2f6a3c6e8b217314a03e2f5d7aeeb13ce847fac6d78020fdc848ea">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

