### PR TITLE
fix: surface exceptions from sync_project worker threads

### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -123,6 +123,27 @@ def _record_task_action(app: App, action: str, ado_id: int, title: str) -> None:
         report.record_task_close(ado_id=ado_id, title=title)
 
 
+def _sync_projects_concurrently(app: App, projects: list, thread_count: int) -> None:
+    """Submit each project to a thread pool and log any exception it raises.
+
+    Consuming futures via as_completed/result() is required to surface
+    exceptions raised in worker threads; executor.map's lazy iterator
+    would otherwise trap them silently.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=thread_count) as executor:
+        future_to_project = {executor.submit(sync_project, app, project): project for project in projects}
+        for future in concurrent.futures.as_completed(future_to_project):
+            project = future_to_project[future]
+            try:
+                future.result()
+            except Exception as exception:  # pylint: disable=broad-exception-caught
+                _LOGGER.error(
+                    "Error syncing project %s: %s",
+                    project.get("adoProjectName", "unknown"),
+                    exception,
+                )
+
+
 def start_sync(app: App) -> None:
     """Start the synchronization process between Azure DevOps and Asana.
 
@@ -165,21 +186,7 @@ def start_sync(app: App) -> None:
                 len(projects),
                 optimal_thread_count,
             )
-            with concurrent.futures.ThreadPoolExecutor(max_workers=optimal_thread_count) as executor:
-                future_to_project = {executor.submit(sync_project, app, project): project for project in projects}
-                # Consuming futures via as_completed/result() is required to surface
-                # exceptions raised in worker threads; executor.map's lazy iterator
-                # would otherwise trap them silently.
-                for future in concurrent.futures.as_completed(future_to_project):
-                    project = future_to_project[future]
-                    try:
-                        future.result()
-                    except Exception as exception:  # pylint: disable=broad-exception-caught
-                        _LOGGER.error(
-                            "Error syncing project %s: %s",
-                            project.get("adoProjectName", "unknown"),
-                            exception,
-                        )
+            _sync_projects_concurrently(app, projects, optimal_thread_count)
 
             if _is_dry_run(app):
                 _get_dry_run_report(app).log_summary()

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -166,10 +166,20 @@ def start_sync(app: App) -> None:
                 optimal_thread_count,
             )
             with concurrent.futures.ThreadPoolExecutor(max_workers=optimal_thread_count) as executor:
-                try:
-                    executor.map(sync_project, [app] * len(projects), projects)
-                except Exception as exception:  # pylint: disable=broad-exception-caught
-                    _LOGGER.error("Error in sync_project thread: %s", exception)
+                future_to_project = {executor.submit(sync_project, app, project): project for project in projects}
+                # Consuming futures via as_completed/result() is required to surface
+                # exceptions raised in worker threads; executor.map's lazy iterator
+                # would otherwise trap them silently.
+                for future in concurrent.futures.as_completed(future_to_project):
+                    project = future_to_project[future]
+                    try:
+                        future.result()
+                    except Exception as exception:  # pylint: disable=broad-exception-caught
+                        _LOGGER.error(
+                            "Error syncing project %s: %s",
+                            project.get("adoProjectName", "unknown"),
+                            exception,
+                        )
 
             if _is_dry_run(app):
                 _get_dry_run_report(app).log_summary()

--- a/tests/sync/test_runtime_modes.py
+++ b/tests/sync/test_runtime_modes.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import unittest
 from io import StringIO
 from types import SimpleNamespace
@@ -20,9 +21,13 @@ class _ExecutorStub:
     def __exit__(self, exc_type, exc, tb):
         return False
 
-    def map(self, func, apps, projects):
-        for app, project in zip(apps, projects, strict=False):
-            func(app, project)
+    def submit(self, func, *args, **kwargs):
+        future = concurrent.futures.Future()
+        try:
+            future.set_result(func(*args, **kwargs))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            future.set_exception(exc)
+        return future
 
 
 class TestRuntimeModes(unittest.TestCase):
@@ -62,6 +67,53 @@ class TestRuntimeModes(unittest.TestCase):
 
         mock_read_projects.assert_called_once_with(app)
         mock_sync_project.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("ado_asana_sync.sync.sync.sleep")
+    @patch("ado_asana_sync.sync.sync.sync_project")
+    @patch(
+        "ado_asana_sync.sync.sync.read_projects",
+        return_value=[
+            {"adoProjectName": "A", "adoTeamName": "team-a"},
+            {"adoProjectName": "B", "adoTeamName": "team-b"},
+        ],
+    )
+    @patch("ado_asana_sync.sync.sync.create_tag_if_not_existing", return_value="tag-gid")
+    @patch("ado_asana_sync.sync.sync.get_asana_workspace", return_value="workspace-gid")
+    @patch("ado_asana_sync.sync.sync._LOGGER")
+    def test_start_sync_logs_exception_from_failing_project(
+        self,
+        mock_logger,
+        _mock_workspace,
+        _mock_tag,
+        _mock_read_projects,
+        mock_sync_project,
+        mock_sleep,
+    ):
+        app = MagicMock()
+        app.asana_workspace_name = "workspace"
+        app.asana_tag_name = "synced"
+        app.run_once = True
+        app.dry_run = False
+        app.sleep_time = 30
+
+        def sync_project_side_effect(_app, project):
+            if project["adoProjectName"] == "A":
+                raise RuntimeError("boom")
+
+        mock_sync_project.side_effect = sync_project_side_effect
+
+        start_sync(app)
+
+        self.assertEqual(mock_sync_project.call_count, 2)
+        logged_failing_project = any(
+            "A" in call_args.args and isinstance(call_args.args[-1], RuntimeError)
+            for call_args in mock_logger.error.call_args_list
+        )
+        self.assertTrue(
+            logged_failing_project,
+            f"Expected an error log mentioning project 'A' and the RuntimeError, got: {mock_logger.error.call_args_list}",
+        )
         mock_sleep.assert_not_called()
 
     @patch("ado_asana_sync.sync.sync.sleep", side_effect=[None, RuntimeError("stop after second cycle")])


### PR DESCRIPTION
### **User description**
## Summary
- `start_sync` used `executor.map(sync_project, ...)`, whose returned iterator was never consumed — worker-thread exceptions stayed trapped in their futures and the surrounding `try/except` never fired, silently swallowing per-project sync failures.
- Switched to `executor.submit` + `concurrent.futures.as_completed`, calling `future.result()` per future inside a `try/except` that logs the failing project name. Each project's outcome is now inspected independently, so one failing project no longer masks failures in the others.
- Updated the test `_ExecutorStub` to implement `submit` (returning a real completed `Future`) instead of the eager `map` stub, which previously masked this exact bug.

## Test plan
- [x] Added `test_start_sync_logs_exception_from_failing_project`, using the real `ThreadPoolExecutor` (not the stub), asserting the failure for one project is logged with its name and exception while both projects are still processed.
- [x] `uv run pytest tests/sync/test_runtime_modes.py -v` — 8 passed
- [x] `uv run test` — 398 passed
- [x] `uv run check` (lint, format, mypy) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix silently swallowed exceptions from `sync_project` worker threads

- Switch from `executor.map` to `executor.submit` + `as_completed`

- Log per-project failures with project name and exception

- Update test stub and add regression test for failing project logging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["start_sync"] -- "executor.submit per project" --> B["future_to_project map"]
  B -- "as_completed" --> C["future.result()"]
  C -- "on exception" --> D["_LOGGER.error with project name"]
  C -- "on success" --> E["continue processing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Surface per-project sync exceptions from worker threads</code>&nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<ul><li>Replaced <code>executor.map</code> (lazy iterator never consumed) with <br><code>executor.submit</code> per project<br> <li> Used <code>concurrent.futures.as_completed</code> to iterate futures and call <br><code>future.result()</code><br> <li> Logs individual project failures with project name and exception, <br>without blocking other projects</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/737/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_runtime_modes.py</strong><dd><code>Add regression test for failing project exception logging</code></dd></summary>
<hr>

tests/sync/test_runtime_modes.py

<ul><li>Updated <code>_ExecutorStub</code> to implement <code>submit</code> returning a real completed <br><code>Future</code> instead of <code>map</code><br> <li> Added <code>test_start_sync_logs_exception_from_failing_project</code> using real <br><code>ThreadPoolExecutor</code><br> <li> Verifies failing project logs error with name and exception while <br>other projects still process</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/737/files#diff-e6c05e0fe6f34a122a4bd19e2c4c8a2901e57b4d8ece0da060ee3b464dbd8c59">+55/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

