### PR TITLE
perf: eliminate redundant ADO and Asana API fetches during task sync

### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -55,6 +55,9 @@ _CLOSED_STATES = {state.strip() for state in os.environ.get("CLOSED_STATES", "Cl
 _THREAD_COUNT = max(1, int(os.environ.get("THREAD_COUNT", 8)))
 # _MAX_DEPTH defines the maximum depth of subtasks to sync
 _MAX_DEPTH = int(os.environ.get("MAX_DEPTH", 3))
+# _UNSET distinguishes "caller did not supply asana_task" from "caller already fetched it and it is None",
+# so a genuinely missing Asana task is not re-fetched.
+_UNSET = object()
 
 # ADO field constants
 ADO_STATE = "System.State"
@@ -752,9 +755,9 @@ def get_existing_match(app, wi):
     return existing_match
 
 
-def update_task_if_needed(app, ado_task, existing_match, asana_users, asana_project, asana_task=None):
+def update_task_if_needed(app, ado_task, existing_match, asana_users, asana_project, asana_task=_UNSET):
     """Updates an Asana task if needed based on the provided Azure DevOps task."""
-    if asana_task is None:
+    if asana_task is _UNSET:
         asana_task = get_asana_task(app, existing_match.asana_gid)
     ado_assigned = get_task_user(ado_task)
     asana_matched_user = matching_user(asana_users, ado_assigned)

--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -646,12 +646,12 @@ def create_new_task_mapping(app, ado_task, asana_matched_user, asana_project_tas
 
 def update_existing_task(app, ado_task, existing_match, asana_matched_user, asana_project, parent_gid=None):
     """Updates an existing Asana task based on ADO changes."""
-    if existing_match.is_current(app):
+    asana_task = get_asana_task(app, existing_match.asana_gid) if existing_match.asana_gid else None
+    if existing_match.is_current(app, ado_task=ado_task, asana_task=asana_task):
         _LOGGER.info("%s:task is already up to date", existing_match.asana_title)
         return
 
     _LOGGER.info("%s:task has been updated, updating task", existing_match.asana_title)
-    asana_task = get_asana_task(app, existing_match.asana_gid)
     if asana_task is None:
         _LOGGER.error("No Asana task found with gid: %s", existing_match.asana_gid)
         return
@@ -706,7 +706,8 @@ def process_closed_items(app, all_tasks, processed_item_ids, asana_users, asana_
             except Exception as e:  # pylint: disable=broad-exception-caught
                 _LOGGER.warning("Failed to fetch work item %s: %s", existing_match.ado_id, e)
                 continue
-            if existing_match.is_current(app):
+            asana_task = get_asana_task(app, existing_match.asana_gid) if existing_match.asana_gid else None
+            if existing_match.is_current(app, ado_task=ado_task, asana_task=asana_task):
                 _LOGGER.info(
                     "%s:Task is up to date",
                     existing_match.asana_title,
@@ -717,7 +718,7 @@ def process_closed_items(app, all_tasks, processed_item_ids, asana_users, asana_
                 "%s:Task has been updated, updating task",
                 existing_match.asana_title,
             )
-            update_task_if_needed(app, ado_task, existing_match, asana_users, asana_project)
+            update_task_if_needed(app, ado_task, existing_match, asana_users, asana_project, asana_task=asana_task)
 
 
 def is_item_older_than_threshold(wi):
@@ -751,9 +752,10 @@ def get_existing_match(app, wi):
     return existing_match
 
 
-def update_task_if_needed(app, ado_task, existing_match, asana_users, asana_project):
+def update_task_if_needed(app, ado_task, existing_match, asana_users, asana_project, asana_task=None):
     """Updates an Asana task if needed based on the provided Azure DevOps task."""
-    asana_task = get_asana_task(app, existing_match.asana_gid)
+    if asana_task is None:
+        asana_task = get_asana_task(app, existing_match.asana_gid)
     ado_assigned = get_task_user(ado_task)
     asana_matched_user = matching_user(asana_users, ado_assigned)
     if asana_task is None:

--- a/ado_asana_sync/sync/task_item.py
+++ b/ado_asana_sync/sync/task_item.py
@@ -10,6 +10,8 @@ from .app import App
 from .asana import get_asana_task
 from .utils import validate_due_date
 
+_UNSET = object()
+
 
 class TaskItem:
     """
@@ -197,24 +199,33 @@ class TaskItem:
         with app.db_lock:
             app.matches.upsert_by_json_fields(task_data, {"ado_id": self.ado_id})
 
-    def is_current(self, app: App) -> bool:
+    def is_current(self, app: App, ado_task: Any = None, asana_task: Any = _UNSET) -> bool:
         """
         Check if the current TaskItem is up-to-date with its corresponding tasks in Azure DevOps (ADO) and Asana.
 
-        This method retrieves the corresponding tasks in ADO and Asana using the stored IDs, and compares their revision number
-        and last updated time with the stored values. If either the ADO task's revision number or the Asana task's last updated
-        time is different from the stored values, the TaskItem is considered not current.
+        This method compares the ADO task's revision number and the Asana task's last updated time with the stored
+        values. If either is different from the stored values, the TaskItem is considered not current.
+
+        Callers that already fetched the ADO work item and/or Asana task in the current sync cycle should pass them
+        in via `ado_task` / `asana_task` to avoid a redundant API call. When omitted, they are fetched using the
+        stored IDs, matching the previous behavior.
 
         Args:
-            a (App): The App instance.
+            app (App): The App instance.
+            ado_task: The already-fetched ADO work item, or None to fetch it using `self.ado_id`.
+            asana_task: The already-fetched Asana task (may legitimately be None if it was fetched and not found).
+                Omit entirely to fetch it using `self.asana_gid`.
 
         Returns:
             bool: True if the TaskItem is current, False otherwise.
         """
-        if app.ado_wit_client is None:
-            return False
-        ado_task = app.ado_wit_client.get_work_item(self.ado_id)
-        asana_task = get_asana_task(app, self.asana_gid) if self.asana_gid else None
+        if ado_task is None:
+            if app.ado_wit_client is None:
+                return False
+            ado_task = app.ado_wit_client.get_work_item(self.ado_id)
+
+        if asana_task is _UNSET:
+            asana_task = get_asana_task(app, self.asana_gid) if self.asana_gid else None
 
         if not ado_task or not asana_task:
             return False

--- a/tests/sync/test_sync_integration.py
+++ b/tests/sync/test_sync_integration.py
@@ -299,3 +299,58 @@ class TestSyncIntegration(unittest.TestCase):
 
         finally:
             app.close()
+
+    @patch("ado_asana_sync.sync.app.os.path.dirname")
+    @patch("ado_asana_sync.sync.app.Connection")
+    @patch("ado_asana_sync.sync.app.asana.ApiClient")
+    def test_process_closed_items_missing_asana_task_does_not_refetch(
+        self, mock_asana_client, mock_ado_connection, mock_dirname
+    ):
+        """When the pre-fetched Asana task is genuinely missing (None), update_task_if_needed must not fetch again."""
+        from ado_asana_sync.sync.sync import process_closed_items
+
+        mock_dirname.return_value = self.temp_dir
+        mock_ado_connection.return_value = MagicMock()
+        mock_asana_client.return_value = MagicMock()
+
+        from datetime import datetime, timezone
+
+        recent_timestamp = datetime.now(timezone.utc).isoformat()
+
+        app = TestDataBuilder.create_real_app(self.temp_dir)
+        app.connect()
+        app.matches.insert(
+            {
+                "ado_id": 3002,
+                "ado_rev": 1,
+                "title": "Old Title",
+                "item_type": "Task",
+                "url": "http://ado/3002",
+                "asana_gid": "deleted_gid",
+                "asana_updated": "2025-01-01T10:00:00.000Z",
+                "created_date": recent_timestamp,
+                "updated_date": recent_timestamp,
+            }
+        )
+        all_tasks = app.matches.all()
+
+        mock_wit_client = MagicMock()
+        app.ado_wit_client = mock_wit_client
+        ado_work_item = TestDataBuilder.create_ado_work_item(item_id=3002, title="New Title", work_item_type="Task")
+        ado_work_item.rev = 2
+        mock_wit_client.get_work_item.return_value = ado_work_item
+
+        asana_helper = AsanaApiMockHelper()
+        mock_tasks_api = asana_helper.create_tasks_api_mock()
+
+        try:
+            with ExitStack() as stack:
+                for patch_ctx in self._setup_asana_api_patches(asana_helper, mock_tasks_api):
+                    stack.enter_context(patch_ctx)
+                with patch("ado_asana_sync.sync.sync.get_asana_task", return_value=None) as mock_get_asana_task:
+                    process_closed_items(app, all_tasks, set(), [], "AsanaProject")
+
+                mock_get_asana_task.assert_called_once()
+
+        finally:
+            app.close()

--- a/tests/sync/test_sync_integration.py
+++ b/tests/sync/test_sync_integration.py
@@ -194,3 +194,108 @@ class TestSyncIntegration(unittest.TestCase):
 
         finally:
             app.close()
+
+    @patch("ado_asana_sync.sync.app.os.path.dirname")
+    @patch("ado_asana_sync.sync.app.Connection")
+    @patch("ado_asana_sync.sync.app.asana.ApiClient")
+    def test_update_existing_task_does_not_double_fetch(self, mock_asana_client, mock_ado_connection, mock_dirname):
+        """update_existing_task must reuse the caller-provided ado_task and fetch the Asana task only once."""
+        from ado_asana_sync.sync.sync import update_existing_task
+        from ado_asana_sync.sync.task_item import TaskItem
+
+        mock_dirname.return_value = self.temp_dir
+        mock_ado_connection.return_value = MagicMock()
+        mock_asana_client.return_value = MagicMock()
+
+        app = TestDataBuilder.create_real_app(self.temp_dir)
+        app.connect()
+
+        mock_wit_client = MagicMock()
+        app.ado_wit_client = mock_wit_client
+
+        ado_work_item = TestDataBuilder.create_ado_work_item(item_id=2001, title="Updated Title", work_item_type="Task")
+        ado_work_item.rev = 2
+
+        existing_match = TaskItem(
+            ado_id=2001,
+            ado_rev=1,
+            title="Old Title",
+            item_type="Task",
+            url="http://ado/2001",
+            asana_gid="existing_gid",
+            asana_updated="2025-01-01T10:00:00.000Z",
+            created_date="2025-01-01T10:00:00.000Z",
+            updated_date="2025-01-01T10:00:00.000Z",
+        )
+
+        mock_asana_task = TestDataBuilder.create_asana_task_data(gid="existing_gid", name="Task 2001: Old Title")
+        asana_helper = AsanaApiMockHelper()
+        mock_tasks_api = asana_helper.create_tasks_api_mock(tasks=[mock_asana_task], updated_task=mock_asana_task)
+
+        try:
+            with ExitStack() as stack:
+                for patch_ctx in self._setup_asana_api_patches(asana_helper, mock_tasks_api):
+                    stack.enter_context(patch_ctx)
+                with patch("ado_asana_sync.sync.sync.get_asana_task", return_value=mock_asana_task) as mock_get_asana_task:
+                    update_existing_task(app, ado_work_item, existing_match, None, "AsanaProject")
+
+                mock_wit_client.get_work_item.assert_not_called()
+                mock_get_asana_task.assert_called_once()
+
+        finally:
+            app.close()
+
+    @patch("ado_asana_sync.sync.app.os.path.dirname")
+    @patch("ado_asana_sync.sync.app.Connection")
+    @patch("ado_asana_sync.sync.app.asana.ApiClient")
+    def test_process_closed_items_single_asana_fetch(self, mock_asana_client, mock_ado_connection, mock_dirname):
+        """process_closed_items must fetch the Asana task once and thread it into is_current and update_task_if_needed."""
+        from ado_asana_sync.sync.sync import process_closed_items
+
+        mock_dirname.return_value = self.temp_dir
+        mock_ado_connection.return_value = MagicMock()
+        mock_asana_client.return_value = MagicMock()
+
+        from datetime import datetime, timezone
+
+        recent_timestamp = datetime.now(timezone.utc).isoformat()
+
+        app = TestDataBuilder.create_real_app(self.temp_dir)
+        app.connect()
+        app.matches.insert(
+            {
+                "ado_id": 3001,
+                "ado_rev": 1,
+                "title": "Old Title",
+                "item_type": "Task",
+                "url": "http://ado/3001",
+                "asana_gid": "existing_gid",
+                "asana_updated": "2025-01-01T10:00:00.000Z",
+                "created_date": recent_timestamp,
+                "updated_date": recent_timestamp,
+            }
+        )
+        all_tasks = app.matches.all()
+
+        mock_wit_client = MagicMock()
+        app.ado_wit_client = mock_wit_client
+        ado_work_item = TestDataBuilder.create_ado_work_item(item_id=3001, title="New Title", work_item_type="Task")
+        ado_work_item.rev = 2
+        mock_wit_client.get_work_item.return_value = ado_work_item
+
+        mock_asana_task = TestDataBuilder.create_asana_task_data(gid="existing_gid", name="Task 3001: Old Title")
+        asana_helper = AsanaApiMockHelper()
+        mock_tasks_api = asana_helper.create_tasks_api_mock(tasks=[mock_asana_task], updated_task=mock_asana_task)
+
+        try:
+            with ExitStack() as stack:
+                for patch_ctx in self._setup_asana_api_patches(asana_helper, mock_tasks_api):
+                    stack.enter_context(patch_ctx)
+                with patch("ado_asana_sync.sync.sync.get_asana_task", return_value=mock_asana_task) as mock_get_asana_task:
+                    process_closed_items(app, all_tasks, set(), [], "AsanaProject")
+
+                self.assertEqual(mock_wit_client.get_work_item.call_count, 1)
+                mock_get_asana_task.assert_called_once()
+
+        finally:
+            app.close()

--- a/tests/sync/test_task_item.py
+++ b/tests/sync/test_task_item.py
@@ -413,6 +413,73 @@ class TestTaskItem(unittest.TestCase):
         # Should return False because asana_task will be None
         self.assertFalse(result)
 
+    def test_is_current_uses_provided_ado_task_without_refetch(self):
+        """Test is_current uses a caller-supplied ado_task instead of re-fetching it."""
+        app = MagicMock()
+        app.ado_wit_client = MagicMock()
+
+        mock_ado_task = MagicMock()
+        mock_ado_task.rev = 5
+        mock_asana_task = {"modified_at": "2023-12-01T10:00:00Z"}
+
+        task_item = TaskItem(
+            ado_id=123,
+            ado_rev=5,
+            title="Test Task",
+            item_type="Bug",
+            url="https://example.com/123",
+            asana_gid="asana-123",
+            asana_updated="2023-12-01T10:00:00Z",
+        )
+
+        result = task_item.is_current(app, ado_task=mock_ado_task, asana_task=mock_asana_task)
+
+        self.assertTrue(result)
+        app.ado_wit_client.get_work_item.assert_not_called()
+
+    def test_is_current_uses_provided_asana_task_without_refetch(self):
+        """Test is_current uses a caller-supplied asana_task instead of calling get_asana_task."""
+        app = MagicMock()
+        app.ado_wit_client = MagicMock()
+
+        mock_ado_task = MagicMock()
+        mock_ado_task.rev = 5
+        mock_asana_task = {"modified_at": "2023-12-01T10:00:00Z"}
+
+        task_item = TaskItem(
+            ado_id=123,
+            ado_rev=5,
+            title="Test Task",
+            item_type="Bug",
+            url="https://example.com/123",
+            asana_gid="asana-123",
+            asana_updated="2023-12-01T10:00:00Z",
+        )
+
+        with patch("ado_asana_sync.sync.task_item.get_asana_task") as mock_get_asana_task:
+            result = task_item.is_current(app, ado_task=mock_ado_task, asana_task=mock_asana_task)
+
+        self.assertTrue(result)
+        mock_get_asana_task.assert_not_called()
+
+    def test_is_current_provided_asana_task_none_does_not_refetch(self):
+        """A caller-supplied asana_task of None (task genuinely missing) must not trigger a re-fetch."""
+        app = MagicMock()
+        app.ado_wit_client = MagicMock()
+
+        mock_ado_task = MagicMock()
+        mock_ado_task.rev = 5
+
+        task_item = TaskItem(
+            ado_id=123, ado_rev=5, title="Test Task", item_type="Bug", url="https://example.com/123", asana_gid="asana-123"
+        )
+
+        with patch("ado_asana_sync.sync.task_item.get_asana_task") as mock_get_asana_task:
+            result = task_item.is_current(app, ado_task=mock_ado_task, asana_task=None)
+
+        self.assertFalse(result)
+        mock_get_asana_task.assert_not_called()
+
     def test_equality_with_different_objects(self):
         """Test equality comparison with different object types."""
         task_item = TaskItem(ado_id=123, ado_rev=1, title="Test Task", item_type="Bug", url="https://example.com/123")


### PR DESCRIPTION
### **User description**
## Summary
- `TaskItem.is_current` now accepts optional pre-fetched `ado_task`/`asana_task` (mirroring `PullRequestItem.is_current`'s existing convention), falling back to its previous self-fetch behavior when omitted.
- `update_existing_task` (backlog/update flow) and `process_closed_items`/`update_task_if_needed` (closed/stale flow) now fetch each ADO work item and Asana task once per sync cycle and thread the results through, instead of re-fetching inside `is_current` and again for the update.
- Net effect: 1 ADO fetch + 1 Asana fetch per checked item, down from 2 ADO fetches (1 redundant) + 2-3 Asana fetches (1-2 redundant).

## Test plan
- [x] RED: added failing tests asserting no re-fetch occurs (`tests/sync/test_task_item.py`, `tests/sync/test_sync_integration.py`)
- [x] GREEN: implemented the optional-parameter threading; all new and existing tests pass
- [x] `uv run test` — 402 passed
- [x] `uv run lint` / `uv run format-check` — clean
- [x] `uv run type-check` — no issues


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Eliminate redundant ADO/Asana API fetches during task sync (AAS-60).

- `TaskItem.is_current` now accepts optional pre-fetched `ado_task`/`asana_task`.

- `update_existing_task` and `process_closed_items`/`update_task_if_needed` reuse fetched data.

- Added tests verifying no duplicate API calls occur.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["update_existing_task"] -- "fetch once" --> B["asana_task"]
  A -- "pass ado_task, asana_task" --> C["TaskItem.is_current"]
  D["process_closed_items"] -- "fetch once" --> E["ado_task"]
  D -- "fetch once" --> B
  D -- "pass ado_task, asana_task" --> C
  D -- "pass asana_task" --> F["update_task_if_needed"]
  F -- "reuse if provided" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Reuse fetched ADO/Asana tasks to avoid duplicate API calls</code></dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<ul><li><code>update_existing_task</code> now fetches <code>asana_task</code> once and passes it into <br><code>is_current</code>, reusing it later instead of re-fetching.<br> <li> <code>process_closed_items</code> fetches <code>asana_task</code> once per item and threads it <br>through to <code>is_current</code> and <code>update_task_if_needed</code>.<br> <li> <code>update_task_if_needed</code> gains an optional <code>asana_task</code> parameter to avoid <br>a redundant fetch when already provided.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/738/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task_item.py</strong><dd><code>Allow `is_current` to accept pre-fetched ADO/Asana tasks</code>&nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/task_item.py

<ul><li><code>TaskItem.is_current</code> now accepts optional <code>ado_task</code> and <code>asana_task</code> <br>parameters to avoid redundant API fetches.<br> <li> Introduced a sentinel <code>_UNSET</code> to distinguish "not provided" from a <br>legitimately <code>None</code> <code>asana_task</code>.<br> <li> Falls back to previous self-fetch behavior when parameters are <br>omitted.<br> <li> Updated docstring to describe new parameters and fetch-avoidance <br>behavior.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/738/files#diff-0fd0b95374ef93889cff36010b72b44a77c0a57d693a2d3a99ad82917bcb89e6">+20/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sync_integration.py</strong><dd><code>Add integration tests for eliminating redundant API fetches</code></dd></summary>
<hr>

tests/sync/test_sync_integration.py

<ul><li>Added <code>test_update_existing_task_does_not_double_fetch</code> to verify no <br>redundant ADO/Asana fetches occur.<br> <li> Added <code>test_process_closed_items_single_asana_fetch</code> to verify a single <br>Asana fetch is threaded through <code>is_current</code> and <code>update_task_if_needed</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/738/files#diff-9e47f4c7b81c34cb0c9b2edb66ea2481128e404248781d4e9c50e0cf3b38d438">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_task_item.py</strong><dd><code>Add unit tests for optional pre-fetched task parameters</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_task_item.py

<ul><li>Added tests confirming <code>is_current</code> uses caller-supplied <code>ado_task</code> <br>without re-fetching.<br> <li> Added tests confirming <code>is_current</code> uses caller-supplied <code>asana_task</code> <br>without calling <code>get_asana_task</code>.<br> <li> Added test ensuring a genuinely <code>None</code> <code>asana_task</code> provided by caller <br>does not trigger a re-fetch.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/738/files#diff-960fbea415e87edb53e4658950b63a6a514be88b83eaea5906f3d7ff3b4b30da">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

