### PR TITLE
docs: align cognitive complexity guidance to max-complexity 15

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,8 @@ Key files:
 
 - Write all code in Python.
 
+- Keep every function at or below a cognitive complexity of 15.
+
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 
 - Enforce markdown formatting with `mdformat` for all `.md` files.
@@ -129,7 +131,7 @@ Every integration test MUST:
 
 All linting and code quality tools are configured in `pyproject.toml` and orchestrated via Python scripts:
 
-- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 10 - Run with `uv run lint` or `uv run format-check`
+- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 15 - Run with `uv run lint` or `uv run format-check`
 - **pytest**: Includes coverage reporting with branch coverage - Run with `uv run test`
 - **mypy**: Static type checking with missing import ignoring - Run with `uv run type-check`
 - **All together**: Run all quality checks in parallel - Run with `uv run check`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ Key files:
 
 - Write all code in Python.
 
-- Keep every function at or below a cognitive complexity of 15.
+- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
 
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ Key files:
 
 - Write all code in Python.
 
-- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
+- Keep every function at or below a cognitive complexity of 15. This is a design guideline for how you write code, separate from Ruff's enforced cyclomatic complexity limit of 10 below.
 
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 
@@ -131,7 +131,7 @@ Every integration test MUST:
 
 All linting and code quality tools are configured in `pyproject.toml` and orchestrated via Python scripts:
 
-- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 15 - Run with `uv run lint` or `uv run format-check`
+- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 10 - Run with `uv run lint` or `uv run format-check`
 - **pytest**: Includes coverage reporting with branch coverage - Run with `uv run test`
 - **mypy**: Static type checking with missing import ignoring - Run with `uv run type-check`
 - **All together**: Run all quality checks in parallel - Run with `uv run check`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Reserve `.all()` for operations that genuinely require every row (e.g. bulk expo
 ### Coding Conventions
 
 - Write all code in Python.
+- Keep every function at or below a cognitive complexity of 15.
 - Run tools using `uv run`.
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 - Adhere to formatting rules defined in `.editorconfig`.
@@ -164,7 +165,7 @@ If `GROUP_REVIEWER_STRATEGY=default_user` but `GROUP_REVIEWER_DEFAULT_USER` is u
 
 ## Quality & Tooling (use tox.ini settings)
 
-- Linting: `uv run lint`, Formatting check: `uv run format-check` (max line length 127, complexity 10)
+- Linting: `uv run lint`, Formatting check: `uv run format-check` (max line length 127, complexity 15)
 - Types: `uv run type-check`
 - All at once: `uv run check` (runs in parallel)
 - Tests + coverage: `uv run test` (coverage enforced ≥ 60%)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Reserve `.all()` for operations that genuinely require every row (e.g. bulk expo
 ### Coding Conventions
 
 - Write all code in Python.
-- Keep every function at or below a cognitive complexity of 15.
+- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
 - Run tools using `uv run`.
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 - Adhere to formatting rules defined in `.editorconfig`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Reserve `.all()` for operations that genuinely require every row (e.g. bulk expo
 ### Coding Conventions
 
 - Write all code in Python.
-- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
+- Keep every function at or below a cognitive complexity of 15. This is a design guideline for how you write code, separate from Ruff's enforced cyclomatic complexity limit of 10 below.
 - Run tools using `uv run`.
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 - Adhere to formatting rules defined in `.editorconfig`.
@@ -165,7 +165,7 @@ If `GROUP_REVIEWER_STRATEGY=default_user` but `GROUP_REVIEWER_DEFAULT_USER` is u
 
 ## Quality & Tooling (use tox.ini settings)
 
-- Linting: `uv run lint`, Formatting check: `uv run format-check` (max line length 127, complexity 15)
+- Linting: `uv run lint`, Formatting check: `uv run format-check` (max line length 127, complexity 10)
 - Types: `uv run type-check`
 - All at once: `uv run check` (runs in parallel)
 - Tests + coverage: `uv run test` (coverage enforced ≥ 60%)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ For **hot-path queries** that filter by indexed fields (`ado_id`, `asana_gid`, `
 Reserve `.all()` for operations that genuinely require every row (e.g. bulk exports, test assertions on full state). Reserve `.search(query_func)` for complex predicates that cannot be expressed as simple equality conditions on indexed fields.
 
 - Write all code in Python.
-- Keep every function at or below a cognitive complexity of 15.
+- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 - Enforce markdown formatting with `mdformat` for all `.md` files.
 - Add dependencies only with `uv add <dependency>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ For **hot-path queries** that filter by indexed fields (`ado_id`, `asana_gid`, `
 Reserve `.all()` for operations that genuinely require every row (e.g. bulk exports, test assertions on full state). Reserve `.search(query_func)` for complex predicates that cannot be expressed as simple equality conditions on indexed fields.
 
 - Write all code in Python.
-- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
+- Keep every function at or below a cognitive complexity of 15. This is a design guideline for how you write code, separate from Ruff's enforced cyclomatic complexity limit of 10 below.
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 - Enforce markdown formatting with `mdformat` for all `.md` files.
 - Add dependencies only with `uv add <dependency>`.
@@ -195,7 +195,7 @@ Always justify internal mocking in test comments and prefer real object approach
 
 All linting and code quality tools are configured in `pyproject.toml` and orchestrated via Python scripts:
 
-- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 15 - Run with `uv run lint` or `uv run format-check` (scans entire project, respects `.gitignore`)
+- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 10 - Run with `uv run lint` or `uv run format-check` (scans entire project, respects `.gitignore`)
 - **pytest**: Includes coverage reporting with branch coverage - Run with `uv run test`
 - **mypy**: Static type checking with missing import ignoring - Run with `uv run type-check`
 - **All together**: Run all quality checks in parallel - Run with `uv run check`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ For **hot-path queries** that filter by indexed fields (`ado_id`, `asana_gid`, `
 Reserve `.all()` for operations that genuinely require every row (e.g. bulk exports, test assertions on full state). Reserve `.search(query_func)` for complex predicates that cannot be expressed as simple equality conditions on indexed fields.
 
 - Write all code in Python.
+- Keep every function at or below a cognitive complexity of 15.
 - Enforce linting and formatting with `ruff` (configured in `pyproject.toml`).
 - Enforce markdown formatting with `mdformat` for all `.md` files.
 - Add dependencies only with `uv add <dependency>`.
@@ -194,7 +195,7 @@ Always justify internal mocking in test comments and prefer real object approach
 
 All linting and code quality tools are configured in `pyproject.toml` and orchestrated via Python scripts:
 
-- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 10 - Run with `uv run lint` or `uv run format-check` (scans entire project, respects `.gitignore`)
+- **ruff**: Handles linting, formatting, and security checks with line length 127 and max complexity 15 - Run with `uv run lint` or `uv run format-check` (scans entire project, respects `.gitignore`)
 - **pytest**: Includes coverage reporting with branch coverage - Run with `uv run test`
 - **mypy**: Static type checking with missing import ignoring - Run with `uv run type-check`
 - **All together**: Run all quality checks in parallel - Run with `uv run check`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,6 +21,7 @@
   - `data/projects.json.example`: Project config example.
 - Run tools using `uv run <tool and args>`.
 - Write Python code only.
+- Keep every function at or below a cognitive complexity of 15.
 - Use `uv run ruff` for linting, formatting, and security checks, plus `.editorconfig`.
 - Add dependencies with `uv add <dependency>`.
 - Always update the readme and other documentation based on the changes made.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,7 +21,7 @@
   - `data/projects.json.example`: Project config example.
 - Run tools using `uv run <tool and args>`.
 - Write Python code only.
-- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
+- Keep every function at or below a cognitive complexity of 15. This is a design guideline for how you write code, separate from Ruff's enforced cyclomatic complexity limit of 10.
 - Use `uv run ruff` for linting, formatting, and security checks, plus `.editorconfig`.
 - Add dependencies with `uv add <dependency>`.
 - Always update the readme and other documentation based on the changes made.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -21,7 +21,7 @@
   - `data/projects.json.example`: Project config example.
 - Run tools using `uv run <tool and args>`.
 - Write Python code only.
-- Keep every function at or below a cognitive complexity of 15.
+- Keep every function at or below a cyclomatic complexity of 15 (enforced by Ruff's McCabe check, `C901`).
 - Use `uv run ruff` for linting, formatting, and security checks, plus `.editorconfig`.
 - Add dependencies with `uv add <dependency>`.
 - Always update the readme and other documentation based on the changes made.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ ignore = [
 "tests/sync/test_sync.py" = ["F401"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 15
+max-complexity = 10
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ ignore = [
 "tests/sync/test_sync.py" = ["F401"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 10
+max-complexity = 15
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
### **User description**
Closes AAS-115

## Summary
- add a cognitive complexity 15 requirement to the AI instruction files
- align the instruction text that describes the Ruff complexity threshold
- update the Ruff mccabe limit in pyproject.toml to match the documented rule


___

### **PR Type**
Documentation


___

### **Description**
- Add cognitive complexity 15 rule to AI instruction files

- Update Ruff mccabe max-complexity from 10 to 15 in `pyproject.toml`

- Align documentation text referencing Ruff complexity threshold


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pyproject.toml
  mccabe max-complexity 10 → 15"] --> B["Instruction docs
  (.github/copilot-instructions.md, AGENTS.md, CLAUDE.md, GEMINI.md)"]
  B --> C["Add cognitive complexity ≤ 15 rule"]
  B --> D["Update complexity references from 10 to 15"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Increase Ruff mccabe max-complexity to 15</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Update `tool.ruff.lint.mccabe.max-complexity` from `10` to `15`


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/741/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copilot-instructions.md</strong><dd><code>Update complexity guidance in copilot instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/copilot-instructions.md

<ul><li>Add rule to keep functions at or below cognitive complexity 15<br> <li> Update ruff description to reference max complexity 15 instead of 10</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/741/files#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Align cognitive complexity guidance in AGENTS.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Add coding convention for cognitive complexity ≤ 15<br> <li> Update quality tooling section to reference complexity 15</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/741/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Align cognitive complexity guidance in CLAUDE.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Add rule for cognitive complexity ≤ 15<br> <li> Update ruff description to reflect max complexity 15</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/741/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GEMINI.md</strong><dd><code>Add cognitive complexity guidance to GEMINI.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

GEMINI.md

<ul><li>Add instruction to keep functions at or below cognitive complexity 15</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/741/files#diff-399080f41ccf73c6004e0f85c0a58fc1767080a0ef19bb3f3a90caa14f94bd79">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

