### PR TITLE
fix: robustly extract work item ID in backlog processing AAS-61

### DIFF
--- a/ado_asana_sync/sync/sync.py
+++ b/ado_asana_sync/sync/sync.py
@@ -75,6 +75,14 @@ CACHE_VALIDITY_DURATION = timedelta(hours=24)
 _CONFIG_IS_NONE_MSG = "app.config is None"
 
 
+def _extract_work_item_id(wi) -> int | None:
+    """Extract a work item ID from either a WorkItemLink or WorkItemReference."""
+    target = getattr(wi, "target", None)
+    if target is not None:
+        return getattr(target, "id", None)
+    return getattr(wi, "id", None)
+
+
 def _parse_sync_threshold(value: str | None) -> int:
     """Parse the sync threshold environment variable into a non-negative integer."""
     if value is None:
@@ -365,7 +373,7 @@ def sync_project(app: App, project):
     )
 
     if ado_items.work_items:
-        item_ids = [item.target.id for item in ado_items.work_items]
+        item_ids = [_id for item in ado_items.work_items if (_id := _extract_work_item_id(item)) is not None]
         _LOGGER.info("Found %d ADO work items in backlog", len(item_ids))
 
     processed_item_ids = process_backlog_items(app, ado_items, asana_users, asana_project_tasks, asana_project)
@@ -451,9 +459,13 @@ def process_backlog_items(app, ado_items, asana_users, asana_project_tasks, asan
     processed_ids = set()
 
     for wi in ado_items.work_items:
+        wi_id = _extract_work_item_id(wi)
+        if wi_id is None:
+            _LOGGER.warning("Could not extract work item ID from %s, skipping", wi)
+            continue
         sync_item_and_children(
             app,
-            wi.target.id,
+            wi_id,
             processed_ids,
             asana_users,
             asana_project_tasks,

--- a/tests/sync/test_sync.py
+++ b/tests/sync/test_sync.py
@@ -3,11 +3,13 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from asana.rest import ApiException
+from azure.devops.v7_0.work.models import WorkItemLink, WorkItemReference
 from azure.devops.v7_0.work_item_tracking.models import WorkItem
 
 from ado_asana_sync.sync.sync import (
     DEFAULT_SYNC_THRESHOLD,
     ADOAssignedUser,
+    _extract_work_item_id,
     _get_deactivated_user_gids,
     _parse_sync_threshold,
     cleanup_invalid_work_items,
@@ -22,6 +24,7 @@ from ado_asana_sync.sync.sync import (
     get_task_user,
     is_item_older_than_threshold,
     matching_user,
+    process_backlog_items,
     read_projects,
     remove_mapping,
     sync_item_and_children,
@@ -294,6 +297,38 @@ class TestMatchingUser(unittest.TestCase):
         result = matching_user([user], ado_user)
 
         self.assertEqual(result, user)
+
+
+class TestExtractWorkItemId(unittest.TestCase):
+    def test_extract_work_item_id_with_work_item_link(self):
+        wi = WorkItemLink(target=WorkItemReference(id=42))
+        self.assertEqual(_extract_work_item_id(wi), 42)
+
+    def test_extract_work_item_id_with_work_item_reference_direct(self):
+        wi = WorkItemReference(id=99)
+        self.assertEqual(_extract_work_item_id(wi), 99)
+
+    def test_extract_work_item_id_with_none_target(self):
+        wi = WorkItemLink()
+        self.assertIsNone(_extract_work_item_id(wi))
+
+    def test_extract_work_item_id_with_no_attributes(self):
+        wi = object()
+        self.assertIsNone(_extract_work_item_id(wi))
+
+
+class TestProcessBacklogItemsSkipsUnextractableIds(unittest.TestCase):
+    @patch("ado_asana_sync.sync.sync.sync_item_and_children")
+    def test_process_backlog_items_skips_items_with_no_extractable_id(self, mock_sync_item_and_children):
+        ado_items = MagicMock()
+        ado_items.work_items = [WorkItemLink()]
+
+        with patch("ado_asana_sync.sync.sync._LOGGER") as mock_logger:
+            processed_ids = process_backlog_items(MagicMock(), ado_items, [], [], "proj")
+
+        mock_sync_item_and_children.assert_not_called()
+        mock_logger.warning.assert_called_once()
+        self.assertEqual(processed_ids, set())
 
 
 class TestSyncItemAndChildrenLogging(unittest.TestCase):


### PR DESCRIPTION
### **User description**
## Summary
- `process_backlog_items` and `sync_project` accessed `wi.target.id` directly, assuming ADO always returns `WorkItemLink` objects with a populated `target`. If the API instead returns a bare `WorkItemReference` (`.id` directly) or a `WorkItemLink` with `target=None`, this raised `AttributeError` and crashed the sync.
- Added a private helper `_extract_work_item_id(wi)` that prefers `target.id` (the primary `WorkItemLink` shape) and falls back to a top-level `.id` (the `WorkItemReference` shape), returning `None` if neither is present.
- Both call sites now use the helper; `process_backlog_items` skips items with no extractable ID and logs a warning instead of crashing.

## Test plan
- [x] Added `TestExtractWorkItemId` covering `WorkItemLink`, direct `WorkItemReference`, `WorkItemLink` with `target=None`, and an object with neither attribute.
- [x] Added a test verifying `process_backlog_items` skips items with no extractable ID, logs a warning, and never calls `sync_item_and_children` for them.
- [x] `uv run test` — 409 passed
- [x] `uv run check` (ruff lint, ruff format, mypy) — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `_extract_work_item_id` helper to safely extract work item ID

- Fix `AttributeError` from `WorkItemLink`/`WorkItemReference` shape mismatch

- Skip unextractable items in `process_backlog_items` with warning log

- Add unit tests for extraction helper and skip behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  wi["ADO work item (WorkItemLink or WorkItemReference)"] -- "extract ID" --> helper["_extract_work_item_id()"]
  helper -- "valid ID" --> sync["sync_item_and_children()"]
  helper -- "no ID" --> skip["log warning & skip"]
  helper -- "used by" --> syncProject["sync_project()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync.py</strong><dd><code>Add safe work item ID extraction helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ado_asana_sync/sync/sync.py

<ul><li>Added <code>_extract_work_item_id(wi)</code> helper to handle both <code>WorkItemLink</code> <br>(via <code>target.id</code>) and <code>WorkItemReference</code> (via <code>.id</code>) shapes<br> <li> Updated <code>sync_project</code> to use the helper when building <code>item_ids</code>, <br>filtering out <code>None</code> values<br> <li> Updated <code>process_backlog_items</code> to use the helper and skip items with <br>unextractable IDs, logging a warning instead of raising <code>AttributeError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/743/files#diff-bff1342bf72ee80994b9872da2e344d3c44c33ef075f942ee8a66c538f545b64">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sync.py</strong><dd><code>Add tests for work item ID extraction and skip logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/sync/test_sync.py

<ul><li>Added imports for <code>WorkItemLink</code>, <code>WorkItemReference</code>, <br><code>_extract_work_item_id</code>, and <code>process_backlog_items</code><br> <li> Added <code>TestExtractWorkItemId</code> test class covering all extraction <br>scenarios<br> <li> Added <code>TestProcessBacklogItemsSkipsUnextractableIds</code> test verifying skip <br>and warning behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/743/files#diff-dac5b229e36d3c4af2b553d8166f028111f08257c36f93dfecb2929b1a2d2cf0">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

