### PR TITLE
docs: add UTC timestamp guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,11 @@ Reserve `.all()` for operations that genuinely require every row (e.g. bulk expo
 - **Coverage**: Ensure test coverage remains above 60% for all changes
 - **Tool Configuration**: **ALWAYS** use the settings defined in `pyproject.toml` for all code quality and linting tools
 
+## Timestamp Guidelines
+
+- Always generate current timestamps with `datetime.now(timezone.utc)`, never bare `datetime.now()`. The latter stamps host-local wall-clock time, which silently skews any field documented as UTC (see `4eeb6b0`, which fixed a host-clock leak that skewed the `SYNC_THRESHOLD` closed-item unmap window by the host's UTC offset).
+- Use `iso8601_utc()` from `ado_asana_sync.utils.date` to render a `datetime` as an ISO 8601 UTC string, e.g. for `updated_date` fields. It normalizes naive datetimes to UTC before formatting, so pass it a `datetime.now(timezone.utc)` value rather than a naive one.
+
 ## Test Quality Standards
 
 **CRITICAL**: Follow these testing principles to avoid brittle, over-mocked tests that provide false confidence:


### PR DESCRIPTION
### **User description**
## Summary
- Adds a "Timestamp Guidelines" section to `CLAUDE.md` mandating `datetime.now(timezone.utc)` over bare `datetime.now()`, referencing the host-clock leak fixed in `4eeb6b0`.
- Documents the `iso8601_utc()` helper from `ado_asana_sync.utils.date` for formatting timestamps as ISO 8601 UTC strings.

## Test plan
- [x] `uv run mdformat --check CLAUDE.md` passes
- Docs-only change, no code/tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Add "Timestamp Guidelines" section to `CLAUDE.md`

- Mandate `datetime.now(timezone.utc)` over bare `datetime.now()`

- Document `iso8601_utc()` helper usage for ISO 8601 UTC formatting

- Reference host-clock leak bug fixed in `4eeb6b0`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLAUDE.md"] -- "adds section" --> B["Timestamp Guidelines"]
  B -- "mandates" --> C["datetime.now(timezone.utc)"]
  B -- "documents" --> D["iso8601_utc() helper"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Add UTC timestamp guidance section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

<ul><li>Adds a new "Timestamp Guidelines" section<br> <li> Mandates <code>datetime.now(timezone.utc)</code> instead of bare <code>datetime.now()</code><br> <li> Documents <code>iso8601_utc()</code> helper from <code>ado_asana_sync.utils.date</code><br> <li> References prior host-clock leak bug fix (<code>4eeb6b0</code>) as rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/ado-asana-sync/pull/767/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

